### PR TITLE
Add `variantFromX` decoders

### DIFF
--- a/src/DecodeBase.re
+++ b/src/DecodeBase.re
@@ -5,7 +5,8 @@ type failure = [
   | `ExpectedInt
   | `ExpectedArray
   | `ExpectedObject
-  | `InvalidDate
+  | `ExpectedValidDate
+  | `ExpectedValidOption
 ];
 
 let failureToString = (v, json) =>
@@ -17,7 +18,8 @@ let failureToString = (v, json) =>
     | `ExpectedInt => "Expected int"
     | `ExpectedArray => "Expected array"
     | `ExpectedObject => "Expected object"
-    | `InvalidDate => "Expected a valid date"
+    | `ExpectedValidDate => "Expected a valid date"
+    | `ExpectedValidOption => "Expected a valid option"
     }
   )
   ++ " but found "
@@ -83,8 +85,25 @@ module DecodeBase =
         ->Js.Date.toJSONUnsafe
         ->Js.Nullable.return
         ->Js.Nullable.isNullable ?
-          T.valErr(`InvalidDate, json) : result->ok
+          T.valErr(`ExpectedValidDate, json) : result->ok
     );
+
+  let variantFromJson = (jsonToJs, jsToVariant, json) =>
+    json->jsonToJs
+    <#> jsToVariant
+    >>= (
+      maybeVariant =>
+        switch (maybeVariant) {
+        | Some(variant) => variant->ok
+        | None => T.valErr(`ExpectedValidOption, json)
+        }
+    );
+
+  let variantFromString = (stringToVariant, json) =>
+    variantFromJson(string, stringToVariant, json);
+
+  let variantFromInt = (intToVariant, json) =>
+    variantFromJson(int, intToVariant, json);
 
   let optional = (decode, json) =>
     switch (Js.Json.decodeNull(json)) {

--- a/src/Decode_AsOption.rei
+++ b/src/Decode_AsOption.rei
@@ -5,6 +5,10 @@ let string: Js.Json.t => option(Js.String.t);
 let float: Js.Json.t => option(float);
 let int: Js.Json.t => option(int);
 let date: Js.Json.t => option(Js.Date.t);
+let variantFromJson:
+  (Js.Json.t => option('a), 'a => option('b), Js.Json.t) => option('b);
+let variantFromString: (string => option('a), Js.Json.t) => option('a);
+let variantFromInt: (int => option('a), Js.Json.t) => option('a);
 
 let optional: (Js.Json.t => option('a), Js.Json.t) => option(option('a));
 

--- a/src/Decode_AsOption.rei
+++ b/src/Decode_AsOption.rei
@@ -4,6 +4,7 @@ let boolean: Js.Json.t => option(bool);
 let string: Js.Json.t => option(Js.String.t);
 let float: Js.Json.t => option(float);
 let int: Js.Json.t => option(int);
+let date: Js.Json.t => option(Js.Date.t);
 
 let optional: (Js.Json.t => option('a), Js.Json.t) => option(option('a));
 

--- a/src/Decode_AsResult_OfParseError.rei
+++ b/src/Decode_AsResult_OfParseError.rei
@@ -59,6 +59,7 @@ let boolean: Js.Json.t => Belt.Result.t(bool, Decode_ParseError.failure);
 let string: Js.Json.t => Belt.Result.t(string, Decode_ParseError.failure);
 let float: Js.Json.t => Belt.Result.t(float, Decode_ParseError.failure);
 let int: Js.Json.t => Belt.Result.t(int, Decode_ParseError.failure);
+let date: Js.Json.t => Belt.Result.t(Js.Date.t, Decode_ParseError.failure);
 
 let optional:
   (Js.Json.t => Belt.Result.t('a, Decode_ParseError.failure), Js.Json.t) =>

--- a/src/Decode_AsResult_OfParseError.rei
+++ b/src/Decode_AsResult_OfParseError.rei
@@ -60,6 +60,19 @@ let string: Js.Json.t => Belt.Result.t(string, Decode_ParseError.failure);
 let float: Js.Json.t => Belt.Result.t(float, Decode_ParseError.failure);
 let int: Js.Json.t => Belt.Result.t(int, Decode_ParseError.failure);
 let date: Js.Json.t => Belt.Result.t(Js.Date.t, Decode_ParseError.failure);
+let variantFromJson:
+  (
+    Js.Json.t => Belt.Result.t('a, Decode_ParseError.failure),
+    'a => option('b),
+    Js.Json.t
+  ) =>
+  Belt.Result.t('b, Decode_ParseError.failure);
+let variantFromString:
+  (string => option('a), Js.Json.t) =>
+  Belt.Result.t('a, Decode_ParseError.failure);
+let variantFromInt:
+  (int => option('a), Js.Json.t) =>
+  Belt.Result.t('a, Decode_ParseError.failure);
 
 let optional:
   (Js.Json.t => Belt.Result.t('a, Decode_ParseError.failure), Js.Json.t) =>

--- a/src/Decode_AsResult_OfStringNel.rei
+++ b/src/Decode_AsResult_OfStringNel.rei
@@ -60,6 +60,19 @@ let string: Js.Json.t => Belt.Result.t(string, NonEmptyList.t(string));
 let float: Js.Json.t => Belt.Result.t(float, NonEmptyList.t(string));
 let int: Js.Json.t => Belt.Result.t(int, NonEmptyList.t(string));
 let date: Js.Json.t => Belt.Result.t(Js.Date.t, NonEmptyList.t(string));
+let variantFromJson:
+  (
+    Js.Json.t => Belt.Result.t('a, NonEmptyList.t(string)),
+    'a => option('b),
+    Js.Json.t
+  ) =>
+  Belt.Result.t('b, NonEmptyList.t(string));
+let variantFromString:
+  (string => option('a), Js.Json.t) =>
+  Belt.Result.t('a, NonEmptyList.t(string));
+let variantFromInt:
+  (int => option('a), Js.Json.t) =>
+  Belt.Result.t('a, NonEmptyList.t(string));
 
 let optional:
   (Js.Json.t => Belt.Result.t('a, NonEmptyList.t(string)), Js.Json.t) =>

--- a/src/Decode_AsResult_OfStringNel.rei
+++ b/src/Decode_AsResult_OfStringNel.rei
@@ -59,6 +59,7 @@ let boolean: Js.Json.t => Belt.Result.t(bool, NonEmptyList.t(string));
 let string: Js.Json.t => Belt.Result.t(string, NonEmptyList.t(string));
 let float: Js.Json.t => Belt.Result.t(float, NonEmptyList.t(string));
 let int: Js.Json.t => Belt.Result.t(int, NonEmptyList.t(string));
+let date: Js.Json.t => Belt.Result.t(Js.Date.t, NonEmptyList.t(string));
 
 let optional:
   (Js.Json.t => Belt.Result.t('a, NonEmptyList.t(string)), Js.Json.t) =>

--- a/test/Decode_Option_test.re
+++ b/test/Decode_Option_test.re
@@ -85,6 +85,34 @@ describe("Test decoding primitive values as option", () => {
   );
 });
 
+[@bs.deriving jsConverter]
+type color = [ | `blue | `red | `green];
+
+[@bs.deriving jsConverter]
+type numbers =
+  | Zero
+  | One
+  | Two;
+
+describe("Test decoding variants as option", () => {
+  test("Can decode string variants", () =>
+    expect(D.variantFromString(colorFromJs, "blue"->Js.Json.string))
+    |> toEqual(Some(`blue))
+  );
+  test("Can decode number variants", () =>
+    expect(D.variantFromInt(numbersFromJs, 0->float_of_int->Js.Json.number))
+    |> toEqual(Some(Zero))
+  );
+  test("Can fail on invalid string options", () =>
+    expect(D.variantFromString(colorFromJs, "yellow"->Js.Json.string))
+    |> toEqual(None)
+  );
+  test("Can fail on invalid number options", () =>
+    expect(D.variantFromInt(numbersFromJs, 5->float_of_int->Js.Json.number))
+    |> toEqual(None)
+  );
+});
+
 describe("Test decoding array as option", () => {
   let jsonArray =
     Js.Json.array([|

--- a/test/Decode_Option_test.re
+++ b/test/Decode_Option_test.re
@@ -28,6 +28,10 @@ describe("Test decoding primitive values as option", () => {
   let jsonFloat = Js.Json.number(1.4);
   let jsonInt = Js.Json.number(4.);
   let jsonNull = Js.Json.null;
+  let dateString = "2018-11-17T05:40:35.869Z";
+  let dateNumber = 1542433304450.0;
+  let jsonDateString = Js.Json.string(dateString);
+  let jsonDateNumber = Js.Json.number(dateNumber);
 
   test("String succeeds on string", () =>
     expect(D.string(jsonString)) |> toEqual(Some("Foo"))
@@ -63,6 +67,21 @@ describe("Test decoding primitive values as option", () => {
   );
   test("Int fails on null", () =>
     expect(D.int(jsonNull)) |> toEqual(None)
+  );
+
+  test("Date succeeds on number value", () =>
+    expect(D.date(jsonDateNumber))
+    |> toEqual(Some(dateNumber->Js.Date.fromFloat))
+  );
+  test("Date succeeds on string value", () =>
+    expect(D.date(jsonDateString))
+    |> toEqual(Some(dateString->Js.Date.fromString))
+  );
+  test("Date fails on an invalid date value", () =>
+    expect(D.date(jsonString)) |> toEqual(None)
+  );
+  test("Date fails on a null value", () =>
+    expect(D.date(jsonNull)) |> toEqual(None)
   );
 });
 
@@ -145,7 +164,7 @@ module Url = {
 describe("Test mapping options with existing Option utilities", () => {
   let url = "http://www.example.com";
   let jsonUrl = Js.Json.string(url);
-  let decoded = D.string(jsonUrl) -> Belt.Option.map(Url.make);
+  let decoded = D.string(jsonUrl)->Belt.Option.map(Url.make);
 
   test("Output of decoding can be mapped using existing Option tools", () =>
     expect(decoded) |> toEqual(Some(Url.make(url)))

--- a/test/Decode_Result_test.re
+++ b/test/Decode_Result_test.re
@@ -137,11 +137,41 @@ describe("Test value decoders", () => {
   );
   test("Date fails on an invalid date value", () =>
     expect(D.date(jsonString))
-    |> toEqual(Error(Val(`InvalidDate, jsonString)))
+    |> toEqual(Error(Val(`ExpectedValidDate, jsonString)))
   );
   test("Date fails on a null value", () =>
     expect(D.date(jsonNull))
     |> toEqual(Error(Val(`ExpectedString, jsonNull)))
+  );
+});
+
+[@bs.deriving jsConverter]
+type color = [ | `blue | `red | `green];
+
+[@bs.deriving jsConverter]
+type numbers =
+  | Zero
+  | One
+  | Two;
+
+describe("Test decoding variants as option", () => {
+  test("Can decode string variants", () =>
+    expect(D.variantFromString(colorFromJs, "blue"->Js.Json.string))
+    |> toEqual(Ok(`blue))
+  );
+  test("Can decode number variants", () =>
+    expect(D.variantFromInt(numbersFromJs, 0->float_of_int->Js.Json.number))
+    |> toEqual(Ok(Zero))
+  );
+  test("Can fail on invalid string options", () =>
+    expect(D.variantFromString(colorFromJs, "yellow"->Js.Json.string))
+    |> toEqual(Error(Val(`ExpectedValidOption, "yellow"->Js.Json.string)))
+  );
+  test("Can fail on invalid number options", () =>
+    expect(D.variantFromInt(numbersFromJs, 5->float_of_int->Js.Json.number))
+    |> toEqual(
+         Error(Val(`ExpectedValidOption, 5->float_of_int->Js.Json.number)),
+       )
   );
 });
 

--- a/test/Decode_Result_test.re
+++ b/test/Decode_Result_test.re
@@ -45,6 +45,10 @@ describe("Test value decoders", () => {
   let jsonInt: Js.Json.t = [%bs.raw {| 4 |}];
   let jsonZero: Js.Json.t = [%bs.raw {| 0 |}];
   let jsonNull = Js.Json.null;
+  let dateString = "2018-11-17T05:40:35.869Z";
+  let dateNumber = 1542433304450.0;
+  let jsonDateString = Js.Json.string(dateString);
+  let jsonDateNumber = Js.Json.number(dateNumber);
 
   test("Boolean succeeds on a boolean", () =>
     expect(D.boolean(jsonBoolean)) |> toEqual(Ok(true))
@@ -121,6 +125,23 @@ describe("Test value decoders", () => {
   test("Int fails on null", () =>
     expect(D.int(jsonNull))
     |> toEqual(Error(Val(`ExpectedNumber, jsonNull)))
+  );
+
+  test("Date succeeds on number value", () =>
+    expect(D.date(jsonDateNumber))
+    |> toEqual(Ok(dateNumber->Js.Date.fromFloat))
+  );
+  test("Date succeeds on string value", () =>
+    expect(D.date(jsonDateString))
+    |> toEqual(Ok(dateString->Js.Date.fromString))
+  );
+  test("Date fails on an invalid date value", () =>
+    expect(D.date(jsonString))
+    |> toEqual(Error(Val(`InvalidDate, jsonString)))
+  );
+  test("Date fails on a null value", () =>
+    expect(D.date(jsonNull))
+    |> toEqual(Error(Val(`ExpectedString, jsonNull)))
   );
 });
 


### PR DESCRIPTION
This adds a base level `variantFromJson` value that will convert JSON
into some value and then take a function that will turn that result into
a variant.

It also has 2 methods that will take that further and convert an
int-based variant from JSON and a string-based variant from JSON.

I've also included tests as well.