### PR TITLE
Add `Pipeline.at` for each decoder

### DIFF
--- a/src/DecodeBase.re
+++ b/src/DecodeBase.re
@@ -216,6 +216,8 @@ module DecodeBase =
 
     let field = (name, decode) => pipe(field(name, decode));
 
+    let at = (fields, decode) => pipe(at(fields, decode));
+
     let optionalField = (name, decode) => pipe(optionalField(name, decode));
 
     let fallback = (name, decode, alt) => pipe(fallback(name, decode, alt));

--- a/src/Decode_AsOption.rei
+++ b/src/Decode_AsOption.rei
@@ -86,6 +86,15 @@ module Pipeline: {
     ) =>
     option('b);
 
+  let at:
+    (
+      list(Js.Dict.key),
+      Js.Json.t => option('a),
+      Js.Json.t => option('a => 'b),
+      Js.Json.t
+    ) =>
+    option('b);
+
   let optionalField:
     (
       Js.Dict.key,

--- a/src/Decode_AsResult_OfParseError.rei
+++ b/src/Decode_AsResult_OfParseError.rei
@@ -192,6 +192,15 @@ module Pipeline: {
     ) =>
     Belt.Result.t('b, Decode_ParseError.failure);
 
+  let at:
+    (
+      list(Js.Dict.key),
+      Js.Json.t => Belt.Result.t('a, Decode_ParseError.failure),
+      Js.Json.t => Belt.Result.t('a => 'b, Decode_ParseError.failure),
+      Js.Json.t
+    ) =>
+    Belt.Result.t('b, Decode_ParseError.failure);
+
   let optionalField:
     (
       Js.Dict.key,

--- a/src/Decode_AsResult_OfStringNel.rei
+++ b/src/Decode_AsResult_OfStringNel.rei
@@ -192,6 +192,15 @@ module Pipeline: {
     ) =>
     Belt.Result.t('b, NonEmptyList.t(string));
 
+  let at:
+    (
+      list(Js.Dict.key),
+      Js.Json.t => Belt.Result.t('a, NonEmptyList.t(string)),
+      Js.Json.t => Belt.Result.t('a => 'b, NonEmptyList.t(string)),
+      Js.Json.t
+    ) =>
+    Belt.Result.t('b, NonEmptyList.t(string));
+
   let optionalField:
     (
       Js.Dict.key,


### PR DESCRIPTION
I was trying to use `D.Pipeline` and noticed that `at` was missing.