### PR TITLE
Rename int to intFromNumber and float to floatFromNumber to avoid shadowing pervasives

### DIFF
--- a/src/DecodeBase.re
+++ b/src/DecodeBase.re
@@ -59,11 +59,15 @@ module DecodeBase =
 
   let string = value(Js.Json.decodeString, `ExpectedString);
 
-  let float = json => value(Js.Json.decodeNumber, `ExpectedNumber, json);
+  let floatFromNumber = json =>
+    value(Js.Json.decodeNumber, `ExpectedNumber, json);
 
-  let int = json => {
+  [@ocaml.deprecated "Use floatFromNumber instead."]
+  let float = floatFromNumber;
+
+  let intFromNumber = json => {
     let isInt = v => v == 0. || mod_float(v, floor(v)) == 0.;
-    float(json)
+    floatFromNumber(json)
     ->(
         M.flat_map(v =>
           if (isInt(v)) {
@@ -75,8 +79,11 @@ module DecodeBase =
       );
   };
 
+  [@ocaml.deprecated "Use intFromNumber instead."]
+  let int = intFromNumber;
+
   let date = json =>
-    json->float
+    json->floatFromNumber
     <#> Js.Date.fromFloat
     <|> (json->string <#> Js.Date.fromString)
     >>= (
@@ -103,7 +110,7 @@ module DecodeBase =
     variantFromJson(string, stringToVariant, json);
 
   let variantFromInt = (intToVariant, json) =>
-    variantFromJson(int, intToVariant, json);
+    variantFromJson(intFromNumber, intToVariant, json);
 
   let optional = (decode, json) =>
     switch (Js.Json.decodeNull(json)) {

--- a/src/Decode_AsOption.rei
+++ b/src/Decode_AsOption.rei
@@ -2,8 +2,12 @@ let ok: 'a => option('a);
 
 let boolean: Js.Json.t => option(bool);
 let string: Js.Json.t => option(Js.String.t);
+[@ocaml.deprecated "Use floatFromNumber instead."]
 let float: Js.Json.t => option(float);
+[@ocaml.deprecated "Use intFromNumber instead."]
 let int: Js.Json.t => option(int);
+let floatFromNumber: Js.Json.t => option(float);
+let intFromNumber: Js.Json.t => option(int);
 let date: Js.Json.t => option(Js.Date.t);
 let variantFromJson:
   (Js.Json.t => option('a), 'a => option('b), Js.Json.t) => option('b);

--- a/src/Decode_AsResult_OfParseError.rei
+++ b/src/Decode_AsResult_OfParseError.rei
@@ -57,8 +57,13 @@ let ok: 'a => Belt.Result.t('a, Decode_ParseError.failure);
 
 let boolean: Js.Json.t => Belt.Result.t(bool, Decode_ParseError.failure);
 let string: Js.Json.t => Belt.Result.t(string, Decode_ParseError.failure);
+[@ocaml.deprecated "Use floatFromNumber instead."]
 let float: Js.Json.t => Belt.Result.t(float, Decode_ParseError.failure);
+[@ocaml.deprecated "Use intFromNumber instead."]
 let int: Js.Json.t => Belt.Result.t(int, Decode_ParseError.failure);
+let floatFromNumber:
+  Js.Json.t => Belt.Result.t(float, Decode_ParseError.failure);
+let intFromNumber: Js.Json.t => Belt.Result.t(int, Decode_ParseError.failure);
 let date: Js.Json.t => Belt.Result.t(Js.Date.t, Decode_ParseError.failure);
 let variantFromJson:
   (

--- a/src/Decode_AsResult_OfStringNel.rei
+++ b/src/Decode_AsResult_OfStringNel.rei
@@ -57,8 +57,13 @@ let ok: 'a => Belt.Result.t('a, NonEmptyList.t(string));
 
 let boolean: Js.Json.t => Belt.Result.t(bool, NonEmptyList.t(string));
 let string: Js.Json.t => Belt.Result.t(string, NonEmptyList.t(string));
+[@ocaml.deprecated "Use floatFromNumber instead."]
 let float: Js.Json.t => Belt.Result.t(float, NonEmptyList.t(string));
+[@ocaml.deprecated "Use intFromNumber instead."]
 let int: Js.Json.t => Belt.Result.t(int, NonEmptyList.t(string));
+let floatFromNumber:
+  Js.Json.t => Belt.Result.t(float, NonEmptyList.t(string));
+let intFromNumber: Js.Json.t => Belt.Result.t(int, NonEmptyList.t(string));
 let date: Js.Json.t => Belt.Result.t(Js.Date.t, NonEmptyList.t(string));
 let variantFromJson:
   (

--- a/test/Decode_Option_test.re
+++ b/test/Decode_Option_test.re
@@ -20,7 +20,9 @@ module User = {
     |> Js.Json.object_;
 
   let decode = json =>
-    make <$> D.field("name", D.string, json) <*> D.field("age", D.int, json);
+    make
+    <$> D.field("name", D.string, json)
+    <*> D.field("age", D.intFromNumber, json);
 };
 
 describe("Test decoding primitive values as option", () => {
@@ -44,29 +46,35 @@ describe("Test decoding primitive values as option", () => {
   );
 
   test("Float succeeds on float", () =>
+    expect(D.floatFromNumber(jsonFloat)) |> toEqual(Some(1.4))
+  );
+  test("Float gives deprecated warning", () =>
     expect(D.float(jsonFloat)) |> toEqual(Some(1.4))
   );
   test("Float succeeds on int", () =>
-    expect(D.float(jsonInt)) |> toEqual(Some(4.0))
+    expect(D.floatFromNumber(jsonInt)) |> toEqual(Some(4.0))
   );
   test("Float fails on string", () =>
-    expect(D.float(jsonString)) |> toEqual(None)
+    expect(D.floatFromNumber(jsonString)) |> toEqual(None)
   );
   test("Float fails on null", () =>
-    expect(D.float(jsonNull)) |> toEqual(None)
+    expect(D.floatFromNumber(jsonNull)) |> toEqual(None)
   );
 
   test("Int succeeds on int", () =>
+    expect(D.intFromNumber(jsonInt)) |> toEqual(Some(4))
+  );
+  test("Int gives deprecated warning", () =>
     expect(D.int(jsonInt)) |> toEqual(Some(4))
   );
   test("Int fails on float", () =>
-    expect(D.int(jsonFloat)) |> toEqual(None)
+    expect(D.intFromNumber(jsonFloat)) |> toEqual(None)
   );
   test("Int fails on string", () =>
-    expect(D.int(jsonString)) |> toEqual(None)
+    expect(D.intFromNumber(jsonString)) |> toEqual(None)
   );
   test("Int fails on null", () =>
-    expect(D.int(jsonNull)) |> toEqual(None)
+    expect(D.intFromNumber(jsonNull)) |> toEqual(None)
   );
 
   test("Date succeeds on number value", () =>
@@ -145,7 +153,7 @@ describe("Test decoding record as option", () => {
     expect(D.field("blah", D.string, obj)) |> toEqual(None)
   );
   test("Field fails when wrong type", () =>
-    expect(D.field("name", D.float, obj)) |> toEqual(None)
+    expect(D.field("name", D.floatFromNumber, obj)) |> toEqual(None)
   );
   test("Decode all fields into record type", () =>
     expect(User.decode(obj)) |> toEqual(Some(User.make("Foo", 30)))
@@ -162,15 +170,16 @@ describe("Test decoding optional fields and values", () => {
     Js.Dict.fromList([("float", jsonFloat), ("empty", jsonNull)])
     |> Js.Json.object_;
 
-  let optMissingField = D.optionalField("x", D.int, jsonObj);
-  let optMissingValue = D.optionalField("empty", D.int, jsonObj);
+  let optMissingField = D.optionalField("x", D.intFromNumber, jsonObj);
+  let optMissingValue = D.optionalField("empty", D.intFromNumber, jsonObj);
   let optFloatAsString = D.optionalField("float", D.string, jsonObj);
 
   test("Present value parses as Some", () =>
-    expect(D.optional(D.float, jsonFloat)) |> toEqual(Some(Some(3.14)))
+    expect(D.optional(D.floatFromNumber, jsonFloat))
+    |> toEqual(Some(Some(3.14)))
   );
   test("Missing optional value parses as Some(None)", () =>
-    expect(D.optional(D.float, jsonNull)) |> toEqual(Some(None))
+    expect(D.optional(D.floatFromNumber, jsonNull)) |> toEqual(Some(None))
   );
   test("Present field with null value parses as None for optional field", () =>
     expect(optMissingField) |> toEqual(Some(None))

--- a/test/Decode_Result_Custom_test.re
+++ b/test/Decode_Result_Custom_test.re
@@ -90,13 +90,17 @@ module Shape = {
   let rect = ((width, height)) => Rect(width, height);
 
   let decodeWH = json =>
-    D.tuple(("width", D.float), ("height", D.float), json);
+    D.tuple(
+      ("width", D.floatFromNumber),
+      ("height", D.floatFromNumber),
+      json,
+    );
 
   /* e.g. { "circle": { "radius": 1.4 }} */
   let decode = json =>
     circle
-    <$> D.at(["circle", "radius"], D.float, json)
-    <|> (square <$> D.at(["square", "length"], D.float, json))
+    <$> D.at(["circle", "radius"], D.floatFromNumber, json)
+    <|> (square <$> D.at(["square", "length"], D.floatFromNumber, json))
     <|> (rect <$> D.field("rectangle", decodeWH, json))
     |> R.mapErr(_ => `InvalidShape(json));
 };
@@ -153,8 +157,10 @@ describe("Test decoding complex ADT from object", () => {
 describe("Test decoding complex ADT with constructor as JSON value", () => {
   let shapeFromKeyJson = (json, key) =>
     switch (key) {
-    | "circle" => Shape.circle <$> D.at(["value", "radius"], D.float, json)
-    | "square" => Shape.square <$> D.at(["value", "length"], D.float, json)
+    | "circle" =>
+      Shape.circle <$> D.at(["value", "radius"], D.floatFromNumber, json)
+    | "square" =>
+      Shape.square <$> D.at(["value", "length"], D.floatFromNumber, json)
     | "rectangle" => Shape.rect <$> D.field("value", Shape.decodeWH, json)
     | other => Error(Val(`InvalidShape, Js.Json.string(other)))
     };

--- a/test/Decode_Result_Pipeline_test.re
+++ b/test/Decode_Result_Pipeline_test.re
@@ -46,7 +46,11 @@ module User = {
 
 describe("Test lazily executing decoders with a single JSON object", () => {
   let decoded =
-    map2(Point.make, D.field("x", D.float), D.field("y", D.float))
+    map2(
+      Point.make,
+      D.field("x", D.floatFromNumber),
+      D.field("y", D.floatFromNumber),
+    )
     |> run(Point.sample);
 
   test("Lazy execution successfully parses point", () =>
@@ -57,8 +61,8 @@ describe("Test lazily executing decoders with a single JSON object", () => {
 describe("Test piping to build up decoders, using |>", () => {
   let decoded =
     succeed(Point.make)
-    |> field("x", D.float)
-    |> field("y", D.float)
+    |> field("x", D.floatFromNumber)
+    |> field("y", D.floatFromNumber)
     |> run(Point.sample);
 
   test("Pipeline of required fields parses point", () =>
@@ -70,7 +74,7 @@ describe("Test optional, fallback, hardcoded helpers", () => {
   let decoder =
     succeed(User.make)
     |> fallback("name", D.string, "Bar")
-    |> optionalField("age", D.int)
+    |> optionalField("age", D.intFromNumber)
     |> optionalField("email", D.string)
     |> hardcoded("No note");
 


### PR DESCRIPTION
As per the discussions in Discord, I've renamed `int` and `float` to avoid shadowing (which caused a warning).  ~~This change would be breaking since those original 2 methods go away.  I think if you leave them in, you'd still get the shadowing warning.~~

I used `intFromNumber` and `floatFromNumber` to match the new `variantFrom*` methods but that might not be the best looking API.  I'm open to changing them to something else.