### PR TITLE
Add Relude, make decoders more composable, clean up public API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ node_modules
 /dist
 .merlin
 .bsb.lock
+/website/build
 
 # os files
 .DS_Store

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -3,7 +3,7 @@
   "bsc-flags": ["-bs-no-version-header", "-bs-super-errors"],
   "bs-dependencies": [
     "bs-abstract",
-    "bs-nonempty"
+    "relude"
   ],
   "bs-dev-dependencies": [
     "@glennsl/bs-jest"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bs-decode",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -864,22 +864,14 @@
       }
     },
     "bs-abstract": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/bs-abstract/-/bs-abstract-0.16.0.tgz",
-      "integrity": "sha512-b1/qOWNBqL44lFciqEs73UxOwxAfnXeQgJtXGlfVwKYMZ6qNKgNrQe3Wokg8awQHs2EkmAJgtxku2zrGlwd/Jw=="
-    },
-    "bs-nonempty": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/bs-nonempty/-/bs-nonempty-1.3.0.tgz",
-      "integrity": "sha512-nNXw8RubW7rlY+t0NTy5pJsnb9/YKvkZhsIbHO/JeM4u1cZfCe0M3sLesxzX2qVXXWdR/GV2ctaGxWYCMQOkbA==",
-      "requires": {
-        "bs-abstract": "^0.16.0"
-      }
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/bs-abstract/-/bs-abstract-0.17.0.tgz",
+      "integrity": "sha512-J1sPz2EZS29Ga0YdOVV8wD7PPKpCxrpEgMKLcehXNseSNxiWgmg4mxmJEhRva/d/d0LpjM4HysBiuCDwZ1FTNQ=="
     },
     "bs-platform": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/bs-platform/-/bs-platform-4.0.18.tgz",
-      "integrity": "sha512-BwzW0iYHvREqUZIgQxJmdJrxexppLvJxYQ4LLexbhCp7uZU5DIZ5ub4ZHpkCkc8fn8bsXWc+Rrejb3csi+BoAQ==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/bs-platform/-/bs-platform-5.0.4.tgz",
+      "integrity": "sha512-rXM+ztN8wYXQ4ojfFGylvPOf8GRLOvM94QJsMMV9VpsLChKCjesWMNybTZvpoyNsESu2nC5q+C9soG+BPhuUFQ==",
       "dev": true
     },
     "bser": {
@@ -4174,6 +4166,11 @@
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
       }
+    },
+    "relude": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/relude/-/relude-0.11.0.tgz",
+      "integrity": "sha512-5GvOmBkBFF1u4zKch9I9a4m2YnaDHSEjanfVfZu/vGRnCSvy4jEufrNXDh91SOXvvfSQWgdcJQTc8IO3XzYcEA=="
     },
     "remove-trailing-separator": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -27,12 +27,12 @@
   "author": "Michael Martin-Smucker",
   "license": "MIT",
   "dependencies": {
-    "bs-abstract": "^0.16.0",
-    "bs-nonempty": "^1.3.0"
+    "bs-abstract": "^0.17.0",
+    "relude": "^0.11.0"
   },
   "devDependencies": {
     "@glennsl/bs-jest": "^0.4.7",
-    "bs-platform": "^4.0.18",
+    "bs-platform": "^5.0.3",
     "jest": "^23.6.0"
   }
 }

--- a/src/DecodeBase.re
+++ b/src/DecodeBase.re
@@ -1,5 +1,3 @@
-module Nel = Relude.NonEmpty.List;
-
 type failure = [
   | `ExpectedBoolean
   | `ExpectedString
@@ -93,8 +91,8 @@ module DecodeBase =
         result
         ->Js.Date.toJSONUnsafe
         ->Js.Nullable.return
-        ->Js.Nullable.isNullable ?
-          T.valErr(`ExpectedValidDate, json) : result->ok
+        ->Js.Nullable.isNullable
+          ? T.valErr(`ExpectedValidDate, json) : result->ok
     );
 
   let variantFromJson = (jsonToJs, jsToVariant, json) =>
@@ -197,12 +195,12 @@ module DecodeBase =
       field(fieldB, decodeB, json),
     );
 
-  let rec oneOf = (decoders, json) =>
-    switch (decoders) {
-    | Nel.NonEmpty(decode, []) => decode(json)
-    | Nel.NonEmpty(decode, [y, ...ys]) =>
-      T.lazyAlt(decode(json), () => oneOf(Nel.make(y, ys), json))
-    };
+  let oneOf = (decode, rest, json) =>
+    Relude.List.foldLeft(
+      (a, b) => T.lazyAlt(a, () => b(json)),
+      decode(json),
+      rest,
+    );
 
   module Pipeline = {
     /**

--- a/src/DecodeBase.re
+++ b/src/DecodeBase.re
@@ -46,11 +46,8 @@ module DecodeBase =
     BsAbstract.Interface.MONAD with type t('a) = Js.Json.t => M.t('a) = {
     type t('a) = Js.Json.t => M.t('a);
     let map = (f, decode) => decode >> M.map(f);
-    let apply = (f, decode, json) =>
-      M.flat_map(f(json), fn => decode(json) |> M.map(fn));
-
+    let apply = (f, decode, json) => M.apply(f(json), decode(json));
     let pure = (v, _) => M.pure(v);
-
     let flat_map = (decode, f, json) =>
       decode(json) |> M.flat_map(_, a => f(a, json));
   };

--- a/src/DecodeBase.re
+++ b/src/DecodeBase.re
@@ -1,3 +1,5 @@
+module Nel = Relude.NonEmpty.List;
+
 type failure = [
   | `ExpectedBoolean
   | `ExpectedString
@@ -197,9 +199,9 @@ module DecodeBase =
 
   let rec oneOf = (decoders, json) =>
     switch (decoders) {
-    | NonEmptyList.NonEmpty(decode, []) => decode(json)
-    | NonEmptyList.NonEmpty(decode, [y, ...ys]) =>
-      T.lazyAlt(decode(json), () => oneOf(NonEmptyList.make(y, ys), json))
+    | Nel.NonEmpty(decode, []) => decode(json)
+    | Nel.NonEmpty(decode, [y, ...ys]) =>
+      T.lazyAlt(decode(json), () => oneOf(Nel.make(y, ys), json))
     };
 
   module Pipeline = {

--- a/src/Decode_AsOption.rei
+++ b/src/Decode_AsOption.rei
@@ -1,44 +1,56 @@
+let map: ('a => 'b, Js.Json.t => option('a), Js.Json.t) => option('b);
+let apply:
+  (Js.Json.t => option('a => 'b), Js.Json.t => option('a), Js.Json.t) =>
+  option('b);
+
 let map2:
-	(
-		('a, 'b) => 'c,
-		Js.Json.t => option('a),
-		Js.Json.t => option('b),
-		Js.Json.t
-	) =>
-	option('c);
+  (
+    ('a, 'b) => 'c,
+    Js.Json.t => option('a),
+    Js.Json.t => option('b),
+    Js.Json.t
+  ) =>
+  option('c);
 
 let map3:
-	(
-		('a, 'b, 'c) => 'd,
-		Js.Json.t => option('a),
-		Js.Json.t => option('b),
-		Js.Json.t => option('c),
-		Js.Json.t
-	) =>
-	option('d);
+  (
+    ('a, 'b, 'c) => 'd,
+    Js.Json.t => option('a),
+    Js.Json.t => option('b),
+    Js.Json.t => option('c),
+    Js.Json.t
+  ) =>
+  option('d);
 
 let map4:
-	(
-		('a, 'b, 'c, 'd) => 'e,
-		Js.Json.t => option('a),
-		Js.Json.t => option('b),
-		Js.Json.t => option('c),
-		Js.Json.t => option('d),
-		Js.Json.t
-	) =>
-	option('e);
+  (
+    ('a, 'b, 'c, 'd) => 'e,
+    Js.Json.t => option('a),
+    Js.Json.t => option('b),
+    Js.Json.t => option('c),
+    Js.Json.t => option('d),
+    Js.Json.t
+  ) =>
+  option('e);
 
 let map5:
-	(
-		('a, 'b, 'c, 'd, 'e) => 'f,
-		Js.Json.t => option('a),
-		Js.Json.t => option('b),
-		Js.Json.t => option('c),
-		Js.Json.t => option('d),
-		Js.Json.t => option('e),
-		Js.Json.t
-	) =>
-	option('f);
+  (
+    ('a, 'b, 'c, 'd, 'e) => 'f,
+    Js.Json.t => option('a),
+    Js.Json.t => option('b),
+    Js.Json.t => option('c),
+    Js.Json.t => option('d),
+    Js.Json.t => option('e),
+    Js.Json.t
+  ) =>
+  option('f);
+
+let pure: ('a, Js.Json.t) => option('a);
+
+let flatMap:
+  (('a, Js.Json.t) => option('b), Js.Json.t => option('a), Js.Json.t) =>
+  option('b);
+
 let boolean: Js.Json.t => option(bool);
 let string: Js.Json.t => option(Js.String.t);
 [@ocaml.deprecated "Use floatFromNumber instead."]
@@ -49,7 +61,7 @@ let floatFromNumber: Js.Json.t => option(float);
 let intFromNumber: Js.Json.t => option(int);
 let date: Js.Json.t => option(Js.Date.t);
 let variantFromJson:
-	(Js.Json.t => option('a), 'a => option('b), Js.Json.t) => option('b);
+  (Js.Json.t => option('a), 'a => option('b), Js.Json.t) => option('b);
 let variantFromString: (string => option('a), Js.Json.t) => option('a);
 let variantFromInt: (int => option('a), Js.Json.t) => option('a);
 
@@ -58,72 +70,72 @@ let optional: (Js.Json.t => option('a), Js.Json.t) => option(option('a));
 let array: (Js.Json.t => option('a), Js.Json.t) => option(array('a));
 let list: (Js.Json.t => option('a), Js.Json.t) => option(list('a));
 let tuple:
-	(
-		(Js.Dict.key, Js.Json.t => option('a)),
-		(Js.Dict.key, Js.Json.t => option('b)),
-		Js.Json.t
-	) =>
-	option(('a, 'b));
+  (
+    (Js.Dict.key, Js.Json.t => option('a)),
+    (Js.Dict.key, Js.Json.t => option('b)),
+    Js.Json.t
+  ) =>
+  option(('a, 'b));
 
 let dict: (Js.Json.t => option('a), Js.Json.t) => option(Js.Dict.t('a));
 
 let at:
-	(list(Js.Dict.key), Js.Json.t => option('a), Js.Json.t) => option('a);
+  (list(Js.Dict.key), Js.Json.t => option('a), Js.Json.t) => option('a);
 
 let field: (Js.Dict.key, Js.Json.t => option('a), Js.Json.t) => option('a);
 
 let optionalField:
-	(Js.Dict.key, Js.Json.t => option('a), Js.Json.t) => option(option('a));
+  (Js.Dict.key, Js.Json.t => option('a), Js.Json.t) => option(option('a));
 
 let fallback:
-	(Js.Dict.key, Js.Json.t => option('a), 'a, Js.Json.t) => option('a);
+  (Js.Dict.key, Js.Json.t => option('a), 'a, Js.Json.t) => option('a);
 
 let oneOf:
-	(Js.Json.t => option('a), list(Js.Json.t => option('a)), Js.Json.t) =>
-	option('a);
+  (Js.Json.t => option('a), list(Js.Json.t => option('a)), Js.Json.t) =>
+  option('a);
 
 module Pipeline: {
-	let succeed: ('a, 'b) => option('a);
+  let succeed: ('a, 'b) => option('a);
 
-	let field:
-		(
-			Js.Dict.key,
-			Js.Json.t => option('a),
-			Js.Json.t => option('a => 'b),
-			Js.Json.t
-		) =>
-		option('b);
+  let field:
+    (
+      Js.Dict.key,
+      Js.Json.t => option('a),
+      Js.Json.t => option('a => 'b),
+      Js.Json.t
+    ) =>
+    option('b);
 
-	let at:
-		(
-			list(Js.Dict.key),
-			Js.Json.t => option('a),
-			Js.Json.t => option('a => 'b),
-			Js.Json.t
-		) =>
-		option('b);
+  let at:
+    (
+      list(Js.Dict.key),
+      Js.Json.t => option('a),
+      Js.Json.t => option('a => 'b),
+      Js.Json.t
+    ) =>
+    option('b);
 
-	let optionalField:
-		(
-			Js.Dict.key,
-			Js.Json.t => option('a),
-			Js.Json.t => option(option('a) => 'b),
-			Js.Json.t
-		) =>
-		option('b);
+  let optionalField:
+    (
+      Js.Dict.key,
+      Js.Json.t => option('a),
+      Js.Json.t => option(option('a) => 'b),
+      Js.Json.t
+    ) =>
+    option('b);
 
-	let fallback:
-		(
-			Js.Dict.key,
-			Js.Json.t => option('a),
-			'a,
-			Js.Json.t => option('a => 'b),
-			Js.Json.t
-		) =>
-		option('b);
+  let fallback:
+    (
+      Js.Dict.key,
+      Js.Json.t => option('a),
+      'a,
+      Js.Json.t => option('a => 'b),
+      Js.Json.t
+    ) =>
+    option('b);
 
-	let hardcoded:
-		('a, Js.Json.t => option('a => 'c), Js.Json.t) => option('c);
+  let hardcoded:
+    ('a, Js.Json.t => option('a => 'c), Js.Json.t) => option('c);
 
-	let run: (Js.Json.t, Js.Json.t => option('a)) => option('a);
+  let run: (Js.Json.t, Js.Json.t => option('a)) => option('a);
 };

--- a/src/Decode_AsOption.rei
+++ b/src/Decode_AsOption.rei
@@ -40,7 +40,7 @@ let fallback:
   (Js.Dict.key, Js.Json.t => option('a), 'a, Js.Json.t) => option('a);
 
 let oneOf:
-  (NonEmptyList.t(Js.Json.t => option('a)), Js.Json.t) => option('a);
+  (Relude.NonEmptyList.t(Js.Json.t => option('a)), Js.Json.t) => option('a);
 
 module Pipeline: {
   let succeed: ('a, 'b) => option('a);

--- a/src/Decode_AsOption.rei
+++ b/src/Decode_AsOption.rei
@@ -1,5 +1,3 @@
-let ok: 'a => option('a);
-
 let boolean: Js.Json.t => option(bool);
 let string: Js.Json.t => option(Js.String.t);
 [@ocaml.deprecated "Use floatFromNumber instead."]

--- a/src/Decode_AsOption.rei
+++ b/src/Decode_AsOption.rei
@@ -40,7 +40,8 @@ let fallback:
   (Js.Dict.key, Js.Json.t => option('a), 'a, Js.Json.t) => option('a);
 
 let oneOf:
-  (Relude.NonEmptyList.t(Js.Json.t => option('a)), Js.Json.t) => option('a);
+  (Js.Json.t => option('a), list(Js.Json.t => option('a)), Js.Json.t) =>
+  option('a);
 
 module Pipeline: {
   let succeed: ('a, 'b) => option('a);

--- a/src/Decode_AsOption.rei
+++ b/src/Decode_AsOption.rei
@@ -1,3 +1,44 @@
+let map2:
+	(
+		('a, 'b) => 'c,
+		Js.Json.t => option('a),
+		Js.Json.t => option('b),
+		Js.Json.t
+	) =>
+	option('c);
+
+let map3:
+	(
+		('a, 'b, 'c) => 'd,
+		Js.Json.t => option('a),
+		Js.Json.t => option('b),
+		Js.Json.t => option('c),
+		Js.Json.t
+	) =>
+	option('d);
+
+let map4:
+	(
+		('a, 'b, 'c, 'd) => 'e,
+		Js.Json.t => option('a),
+		Js.Json.t => option('b),
+		Js.Json.t => option('c),
+		Js.Json.t => option('d),
+		Js.Json.t
+	) =>
+	option('e);
+
+let map5:
+	(
+		('a, 'b, 'c, 'd, 'e) => 'f,
+		Js.Json.t => option('a),
+		Js.Json.t => option('b),
+		Js.Json.t => option('c),
+		Js.Json.t => option('d),
+		Js.Json.t => option('e),
+		Js.Json.t
+	) =>
+	option('f);
 let boolean: Js.Json.t => option(bool);
 let string: Js.Json.t => option(Js.String.t);
 [@ocaml.deprecated "Use floatFromNumber instead."]
@@ -8,7 +49,7 @@ let floatFromNumber: Js.Json.t => option(float);
 let intFromNumber: Js.Json.t => option(int);
 let date: Js.Json.t => option(Js.Date.t);
 let variantFromJson:
-  (Js.Json.t => option('a), 'a => option('b), Js.Json.t) => option('b);
+	(Js.Json.t => option('a), 'a => option('b), Js.Json.t) => option('b);
 let variantFromString: (string => option('a), Js.Json.t) => option('a);
 let variantFromInt: (int => option('a), Js.Json.t) => option('a);
 
@@ -17,107 +58,72 @@ let optional: (Js.Json.t => option('a), Js.Json.t) => option(option('a));
 let array: (Js.Json.t => option('a), Js.Json.t) => option(array('a));
 let list: (Js.Json.t => option('a), Js.Json.t) => option(list('a));
 let tuple:
-  (
-    (Js.Dict.key, Js.Json.t => option('a)),
-    (Js.Dict.key, Js.Json.t => option('b)),
-    Js.Json.t
-  ) =>
-  option(('a, 'b));
+	(
+		(Js.Dict.key, Js.Json.t => option('a)),
+		(Js.Dict.key, Js.Json.t => option('b)),
+		Js.Json.t
+	) =>
+	option(('a, 'b));
 
 let dict: (Js.Json.t => option('a), Js.Json.t) => option(Js.Dict.t('a));
 
 let at:
-  (list(Js.Dict.key), Js.Json.t => option('a), Js.Json.t) => option('a);
+	(list(Js.Dict.key), Js.Json.t => option('a), Js.Json.t) => option('a);
 
 let field: (Js.Dict.key, Js.Json.t => option('a), Js.Json.t) => option('a);
 
 let optionalField:
-  (Js.Dict.key, Js.Json.t => option('a), Js.Json.t) => option(option('a));
+	(Js.Dict.key, Js.Json.t => option('a), Js.Json.t) => option(option('a));
 
 let fallback:
-  (Js.Dict.key, Js.Json.t => option('a), 'a, Js.Json.t) => option('a);
+	(Js.Dict.key, Js.Json.t => option('a), 'a, Js.Json.t) => option('a);
 
 let oneOf:
-  (Js.Json.t => option('a), list(Js.Json.t => option('a)), Js.Json.t) =>
-  option('a);
+	(Js.Json.t => option('a), list(Js.Json.t => option('a)), Js.Json.t) =>
+	option('a);
 
 module Pipeline: {
-  let succeed: ('a, 'b) => option('a);
+	let succeed: ('a, 'b) => option('a);
 
-  let map2:
-    (('a, 'b) => 'c, 'd => option('a), 'd => option('b), 'd) => option('c);
+	let field:
+		(
+			Js.Dict.key,
+			Js.Json.t => option('a),
+			Js.Json.t => option('a => 'b),
+			Js.Json.t
+		) =>
+		option('b);
 
-  let map3:
-    (
-      ('a, 'b, 'c) => 'd,
-      'e => option('a),
-      'e => option('b),
-      'e => option('c),
-      'e
-    ) =>
-    option('d);
+	let at:
+		(
+			list(Js.Dict.key),
+			Js.Json.t => option('a),
+			Js.Json.t => option('a => 'b),
+			Js.Json.t
+		) =>
+		option('b);
 
-  let map4:
-    (
-      ('a, 'b, 'c, 'd) => 'e,
-      'f => option('a),
-      'f => option('b),
-      'f => option('c),
-      'f => option('d),
-      'f
-    ) =>
-    option('e);
+	let optionalField:
+		(
+			Js.Dict.key,
+			Js.Json.t => option('a),
+			Js.Json.t => option(option('a) => 'b),
+			Js.Json.t
+		) =>
+		option('b);
 
-  let map5:
-    (
-      ('a, 'b, 'c, 'd, 'e) => 'f,
-      'g => option('a),
-      'g => option('b),
-      'g => option('c),
-      'g => option('d),
-      'g => option('e),
-      'g
-    ) =>
-    option('f);
+	let fallback:
+		(
+			Js.Dict.key,
+			Js.Json.t => option('a),
+			'a,
+			Js.Json.t => option('a => 'b),
+			Js.Json.t
+		) =>
+		option('b);
 
-  let field:
-    (
-      Js.Dict.key,
-      Js.Json.t => option('a),
-      Js.Json.t => option('a => 'b),
-      Js.Json.t
-    ) =>
-    option('b);
+	let hardcoded:
+		('a, Js.Json.t => option('a => 'c), Js.Json.t) => option('c);
 
-  let at:
-    (
-      list(Js.Dict.key),
-      Js.Json.t => option('a),
-      Js.Json.t => option('a => 'b),
-      Js.Json.t
-    ) =>
-    option('b);
-
-  let optionalField:
-    (
-      Js.Dict.key,
-      Js.Json.t => option('a),
-      Js.Json.t => option(option('a) => 'b),
-      Js.Json.t
-    ) =>
-    option('b);
-
-  let fallback:
-    (
-      Js.Dict.key,
-      Js.Json.t => option('a),
-      'a,
-      Js.Json.t => option('a => 'b),
-      Js.Json.t
-    ) =>
-    option('b);
-
-  let hardcoded: ('a, 'b => option('a => 'c), 'b) => option('c);
-
-  let run: (Js.Json.t, Js.Json.t => option('a)) => option('a);
+	let run: (Js.Json.t, Js.Json.t => option('a)) => option('a);
 };

--- a/src/Decode_AsResult_OfParseError.re
+++ b/src/Decode_AsResult_OfParseError.re
@@ -1,3 +1,5 @@
+module NonEmptyList = Relude.NonEmpty.List;
+
 module ResultUtil =
   Decode_ParseError.ResultOf({
     type t = DecodeBase.failure;

--- a/src/Decode_AsResult_OfParseError.rei
+++ b/src/Decode_AsResult_OfParseError.rei
@@ -55,8 +55,6 @@ module ResultUtil: {
     Belt.Result.t('a, Decode_ParseError.failure);
 };
 
-let ok: 'a => Belt.Result.t('a, Decode_ParseError.failure);
-
 let boolean: Js.Json.t => Belt.Result.t(bool, Decode_ParseError.failure);
 let string: Js.Json.t => Belt.Result.t(string, Decode_ParseError.failure);
 [@ocaml.deprecated "Use floatFromNumber instead."]

--- a/src/Decode_AsResult_OfParseError.rei
+++ b/src/Decode_AsResult_OfParseError.rei
@@ -1,5 +1,21 @@
 module NonEmptyList: Decode_NonEmptyList.Nel;
 
+let map:
+  (
+    'a => 'b,
+    Js.Json.t => Belt.Result.t('a, Decode_ParseError.failure),
+    Js.Json.t
+  ) =>
+  Belt.Result.t('b, Decode_ParseError.failure);
+
+let apply:
+  (
+    Js.Json.t => Belt.Result.t('a => 'b, Decode_ParseError.failure),
+    Js.Json.t => Belt.Result.t('a, Decode_ParseError.failure),
+    Js.Json.t
+  ) =>
+  Belt.Result.t('b, Decode_ParseError.failure);
+
 let map2:
   (
     ('a, 'b) => 'c,
@@ -42,58 +58,15 @@ let map5:
   ) =>
   Belt.Result.t('f, Decode_ParseError.failure);
 
-module ResultUtil: {
-  type r('a) = Belt.Result.t('a, Decode_ParseError.failure);
+let pure: ('a, Js.Json.t) => Belt.Result.t('a, Decode_ParseError.failure);
 
-  let mapErr: ('a => 'b, Belt.Result.t('c, 'a)) => Belt.Result.t('c, 'b);
-
-  module Functor: {
-    type t('a) = r('a);
-    let map: ('a => 'b, t('a)) => t('b);
-  };
-
-  module Apply: {
-    type t('a) = r('a);
-    let map: ('a => 'b, t('a)) => t('b);
-    let apply: (t('a => 'b), t('a)) => t('b);
-  };
-
-  module Applicative: {
-    type t('a) = r('a);
-    let map: ('a => 'b, t('a)) => t('b);
-    let apply: (t('a => 'b), t('a)) => t('b);
-    let pure: 'a => t('a);
-  };
-
-  module Monad: {
-    type t('a) = r('a);
-    let map: ('a => 'b, t('a)) => t('b);
-    let apply: (t('a => 'b), t('a)) => t('b);
-    let pure: 'a => t('a);
-    let flat_map: (t('a), 'a => t('b)) => t('b);
-  };
-
-  module Alt: {
-    type t('a) = r('a);
-    let map: ('a => 'b, t('a)) => t('b);
-    let alt: (t('a), t('a)) => t('a);
-  };
-
-  module Infix: {
-    let (<*>): (r('a => 'b), r('a)) => r('b);
-    let (>>=): (r('a), 'a => r('b)) => r('b);
-    let (=<<): ('a => r('b), r('a)) => r('b);
-    let (>=>): ('a => r('b), 'b => r('c), 'a) => r('c);
-    let (<=<): ('a => r('b), 'c => r('a), 'c) => r('b);
-    let (<$>): ('a => 'b, r('a)) => r('b);
-    let (<#>): (r('a), 'a => 'b) => r('b);
-    let (<|>): (r('a), r('a)) => r('a);
-  };
-
-  let recoverWith:
-    ('a, Belt.Result.t('a, Decode_ParseError.failure)) =>
-    Belt.Result.t('a, Decode_ParseError.failure);
-};
+let flatMap:
+  (
+    ('a, Js.Json.t) => Belt.Result.t('b, Decode_ParseError.failure),
+    Js.Json.t => Belt.Result.t('a, Decode_ParseError.failure),
+    Js.Json.t
+  ) =>
+  Belt.Result.t('b, Decode_ParseError.failure);
 
 let boolean: Js.Json.t => Belt.Result.t(bool, Decode_ParseError.failure);
 let string: Js.Json.t => Belt.Result.t(string, Decode_ParseError.failure);

--- a/src/Decode_AsResult_OfParseError.rei
+++ b/src/Decode_AsResult_OfParseError.rei
@@ -140,7 +140,8 @@ let fallback:
 
 let oneOf:
   (
-    NonEmptyList.t(Js.Json.t => Belt.Result.t('a, Decode_ParseError.failure)),
+    Js.Json.t => Belt.Result.t('a, Decode_ParseError.failure),
+    list(Js.Json.t => Belt.Result.t('a, Decode_ParseError.failure)),
     Js.Json.t
   ) =>
   Belt.Result.t('a, Decode_ParseError.failure);

--- a/src/Decode_AsResult_OfParseError.rei
+++ b/src/Decode_AsResult_OfParseError.rei
@@ -1,5 +1,47 @@
 module NonEmptyList: Decode_NonEmptyList.Nel;
 
+let map2:
+  (
+    ('a, 'b) => 'c,
+    Js.Json.t => Belt.Result.t('a, Decode_ParseError.failure),
+    Js.Json.t => Belt.Result.t('b, Decode_ParseError.failure),
+    Js.Json.t
+  ) =>
+  Belt.Result.t('c, Decode_ParseError.failure);
+
+let map3:
+  (
+    ('a, 'b, 'c) => 'd,
+    Js.Json.t => Belt.Result.t('a, Decode_ParseError.failure),
+    Js.Json.t => Belt.Result.t('b, Decode_ParseError.failure),
+    Js.Json.t => Belt.Result.t('c, Decode_ParseError.failure),
+    Js.Json.t
+  ) =>
+  Belt.Result.t('d, Decode_ParseError.failure);
+
+let map4:
+  (
+    ('a, 'b, 'c, 'd) => 'e,
+    Js.Json.t => Belt.Result.t('a, Decode_ParseError.failure),
+    Js.Json.t => Belt.Result.t('b, Decode_ParseError.failure),
+    Js.Json.t => Belt.Result.t('c, Decode_ParseError.failure),
+    Js.Json.t => Belt.Result.t('d, Decode_ParseError.failure),
+    Js.Json.t
+  ) =>
+  Belt.Result.t('e, Decode_ParseError.failure);
+
+let map5:
+  (
+    ('a, 'b, 'c, 'd, 'e) => 'f,
+    Js.Json.t => Belt.Result.t('a, Decode_ParseError.failure),
+    Js.Json.t => Belt.Result.t('b, Decode_ParseError.failure),
+    Js.Json.t => Belt.Result.t('c, Decode_ParseError.failure),
+    Js.Json.t => Belt.Result.t('d, Decode_ParseError.failure),
+    Js.Json.t => Belt.Result.t('e, Decode_ParseError.failure),
+    Js.Json.t
+  ) =>
+  Belt.Result.t('f, Decode_ParseError.failure);
+
 module ResultUtil: {
   type r('a) = Belt.Result.t('a, Decode_ParseError.failure);
 
@@ -147,48 +189,6 @@ let oneOf:
 module Pipeline: {
   let succeed: ('a, 'b) => Belt.Result.t('a, Decode_ParseError.failure);
 
-  let map2:
-    (
-      ('a, 'b) => 'c,
-      'd => Belt.Result.t('a, Decode_ParseError.failure),
-      'd => Belt.Result.t('b, Decode_ParseError.failure),
-      'd
-    ) =>
-    Belt.Result.t('c, Decode_ParseError.failure);
-
-  let map3:
-    (
-      ('a, 'b, 'c) => 'd,
-      'e => Belt.Result.t('a, Decode_ParseError.failure),
-      'e => Belt.Result.t('b, Decode_ParseError.failure),
-      'e => Belt.Result.t('c, Decode_ParseError.failure),
-      'e
-    ) =>
-    Belt.Result.t('d, Decode_ParseError.failure);
-
-  let map4:
-    (
-      ('a, 'b, 'c, 'd) => 'e,
-      'f => Belt.Result.t('a, Decode_ParseError.failure),
-      'f => Belt.Result.t('b, Decode_ParseError.failure),
-      'f => Belt.Result.t('c, Decode_ParseError.failure),
-      'f => Belt.Result.t('d, Decode_ParseError.failure),
-      'f
-    ) =>
-    Belt.Result.t('e, Decode_ParseError.failure);
-
-  let map5:
-    (
-      ('a, 'b, 'c, 'd, 'e) => 'f,
-      'g => Belt.Result.t('a, Decode_ParseError.failure),
-      'g => Belt.Result.t('b, Decode_ParseError.failure),
-      'g => Belt.Result.t('c, Decode_ParseError.failure),
-      'g => Belt.Result.t('d, Decode_ParseError.failure),
-      'g => Belt.Result.t('e, Decode_ParseError.failure),
-      'g
-    ) =>
-    Belt.Result.t('f, Decode_ParseError.failure);
-
   let field:
     (
       Js.Dict.key,
@@ -227,7 +227,11 @@ module Pipeline: {
     Belt.Result.t('b, Decode_ParseError.failure);
 
   let hardcoded:
-    ('a, 'b => Belt.Result.t('a => 'c, Decode_ParseError.failure), 'b) =>
+    (
+      'a,
+      Js.Json.t => Belt.Result.t('a => 'c, Decode_ParseError.failure),
+      Js.Json.t
+    ) =>
     Belt.Result.t('c, Decode_ParseError.failure);
 
   let run:

--- a/src/Decode_AsResult_OfParseError.rei
+++ b/src/Decode_AsResult_OfParseError.rei
@@ -45,7 +45,6 @@ let map5:
 module ResultUtil: {
   type r('a) = Belt.Result.t('a, Decode_ParseError.failure);
 
-  let result: ('a => 'b, 'c => 'b, Belt.Result.t('a, 'c)) => 'b;
   let mapErr: ('a => 'b, Belt.Result.t('c, 'a)) => Belt.Result.t('c, 'b);
 
   module Functor: {
@@ -91,7 +90,6 @@ module ResultUtil: {
     let (<|>): (r('a), r('a)) => r('a);
   };
 
-  let note: ('a, option('b)) => Belt.Result.t('b, 'a);
   let recoverWith:
     ('a, Belt.Result.t('a, Decode_ParseError.failure)) =>
     Belt.Result.t('a, Decode_ParseError.failure);

--- a/src/Decode_AsResult_OfParseError.rei
+++ b/src/Decode_AsResult_OfParseError.rei
@@ -1,3 +1,5 @@
+module NonEmptyList: Decode_NonEmptyList.Nel;
+
 module ResultUtil: {
   type r('a) = Belt.Result.t('a, Decode_ParseError.failure);
 

--- a/src/Decode_AsResult_OfStringNel.re
+++ b/src/Decode_AsResult_OfStringNel.re
@@ -1,3 +1,5 @@
+module NonEmptyList = Relude.NonEmpty.List;
+
 module ResultUtil = {
   open BsAbstract;
   open BsAbstract.Interface;

--- a/src/Decode_AsResult_OfStringNel.re
+++ b/src/Decode_AsResult_OfStringNel.re
@@ -10,10 +10,6 @@ module ResultUtil = {
 
   type r('a) = Belt.Result.t('a, NelStr.t);
 
-  let result = Result.result;
-  let mapErr = (v, fn) =>
-    Result.Bifunctor.bimap(BsAbstract.Functions.id, v, fn);
-
   module Functor: FUNCTOR with type t('a) = r('a) = Result.Functor(NelStr);
 
   module Apply: APPLY with type t('a) = r('a) = Result.Apply(NelStr);
@@ -24,11 +20,6 @@ module ResultUtil = {
   module Monad: MONAD with type t('a) = r('a) = Result.Monad(NelStr);
 
   module Alt: ALT with type t('a) = r('a) = Result.Alt(NelStr);
-
-  module Infix = {
-    include BsAbstract.Infix.Monad(Monad);
-    include BsAbstract.Infix.Alt(Alt);
-  };
 
   module Transform: DecodeBase.TransformError with type t('a) = r('a) = {
     type nonrec t('a) = r('a);
@@ -64,14 +55,6 @@ module ResultUtil = {
       | Belt.Result.Error(_) => fn()
       };
   };
-
-  let note = failure =>
-    BsAbstract.Option.maybe(
-      ~f=a => Belt.Result.Ok(a),
-      ~default=Belt.Result.Error(failure),
-    );
-
-  let recoverWith = a => Alt.alt(_, Applicative.pure(a));
 };
 
 module D =

--- a/src/Decode_AsResult_OfStringNel.rei
+++ b/src/Decode_AsResult_OfStringNel.rei
@@ -1,3 +1,5 @@
+module NonEmptyList: Decode_NonEmptyList.Nel;
+
 module ResultUtil: {
   type r('a) = Belt.Result.t('a, NonEmptyList.t(string));
 

--- a/src/Decode_AsResult_OfStringNel.rei
+++ b/src/Decode_AsResult_OfStringNel.rei
@@ -140,7 +140,8 @@ let fallback:
 
 let oneOf:
   (
-    NonEmptyList.t(Js.Json.t => Belt.Result.t('a, NonEmptyList.t(string))),
+    Js.Json.t => Belt.Result.t('a, NonEmptyList.t(string)),
+    list(Js.Json.t => Belt.Result.t('a, NonEmptyList.t(string))),
     Js.Json.t
   ) =>
   Belt.Result.t('a, NonEmptyList.t(string));

--- a/src/Decode_AsResult_OfStringNel.rei
+++ b/src/Decode_AsResult_OfStringNel.rei
@@ -55,8 +55,6 @@ module ResultUtil: {
     Belt.Result.t('a, NonEmptyList.t(string));
 };
 
-let ok: 'a => Belt.Result.t('a, NonEmptyList.t(string));
-
 let boolean: Js.Json.t => Belt.Result.t(bool, NonEmptyList.t(string));
 let string: Js.Json.t => Belt.Result.t(string, NonEmptyList.t(string));
 [@ocaml.deprecated "Use floatFromNumber instead."]

--- a/src/Decode_AsResult_OfStringNel.rei
+++ b/src/Decode_AsResult_OfStringNel.rei
@@ -42,61 +42,6 @@ let map5:
   ) =>
   Belt.Result.t('f, NonEmptyList.t(string));
 
-module ResultUtil: {
-  type r('a) = Belt.Result.t('a, NonEmptyList.t(string));
-
-  let result: ('a => 'b, 'c => 'b, Belt.Result.t('a, 'c)) => 'b;
-  let mapErr: ('a => 'b, Belt.Result.t('c, 'a)) => Belt.Result.t('c, 'b);
-
-  module Functor: {
-    type t('a) = r('a);
-    let map: ('a => 'b, t('a)) => t('b);
-  };
-
-  module Apply: {
-    type t('a) = r('a);
-    let map: ('a => 'b, t('a)) => t('b);
-    let apply: (t('a => 'b), t('a)) => t('b);
-  };
-
-  module Applicative: {
-    type t('a) = r('a);
-    let map: ('a => 'b, t('a)) => t('b);
-    let apply: (t('a => 'b), t('a)) => t('b);
-    let pure: 'a => t('a);
-  };
-
-  module Monad: {
-    type t('a) = r('a);
-    let map: ('a => 'b, t('a)) => t('b);
-    let apply: (t('a => 'b), t('a)) => t('b);
-    let pure: 'a => t('a);
-    let flat_map: (t('a), 'a => t('b)) => t('b);
-  };
-
-  module Alt: {
-    type t('a) = r('a);
-    let map: ('a => 'b, t('a)) => t('b);
-    let alt: (t('a), t('a)) => t('a);
-  };
-
-  module Infix: {
-    let (<*>): (r('a => 'b), r('a)) => r('b);
-    let (>>=): (r('a), 'a => r('b)) => r('b);
-    let (=<<): ('a => r('b), r('a)) => r('b);
-    let (>=>): ('a => r('b), 'b => r('c), 'a) => r('c);
-    let (<=<): ('a => r('b), 'c => r('a), 'c) => r('b);
-    let (<$>): ('a => 'b, r('a)) => r('b);
-    let (<#>): (r('a), 'a => 'b) => r('b);
-    let (<|>): (r('a), r('a)) => r('a);
-  };
-
-  let note: ('a, option('b)) => Belt.Result.t('b, 'a);
-  let recoverWith:
-    ('a, Belt.Result.t('a, NonEmptyList.t(string))) =>
-    Belt.Result.t('a, NonEmptyList.t(string));
-};
-
 let boolean: Js.Json.t => Belt.Result.t(bool, NonEmptyList.t(string));
 let string: Js.Json.t => Belt.Result.t(string, NonEmptyList.t(string));
 [@ocaml.deprecated "Use floatFromNumber instead."]

--- a/src/Decode_AsResult_OfStringNel.rei
+++ b/src/Decode_AsResult_OfStringNel.rei
@@ -1,5 +1,47 @@
 module NonEmptyList: Decode_NonEmptyList.Nel;
 
+let map2:
+  (
+    ('a, 'b) => 'c,
+    Js.Json.t => Belt.Result.t('a, NonEmptyList.t(string)),
+    Js.Json.t => Belt.Result.t('b, NonEmptyList.t(string)),
+    Js.Json.t
+  ) =>
+  Belt.Result.t('c, NonEmptyList.t(string));
+
+let map3:
+  (
+    ('a, 'b, 'c) => 'd,
+    Js.Json.t => Belt.Result.t('a, NonEmptyList.t(string)),
+    Js.Json.t => Belt.Result.t('b, NonEmptyList.t(string)),
+    Js.Json.t => Belt.Result.t('c, NonEmptyList.t(string)),
+    Js.Json.t
+  ) =>
+  Belt.Result.t('d, NonEmptyList.t(string));
+
+let map4:
+  (
+    ('a, 'b, 'c, 'd) => 'e,
+    Js.Json.t => Belt.Result.t('a, NonEmptyList.t(string)),
+    Js.Json.t => Belt.Result.t('b, NonEmptyList.t(string)),
+    Js.Json.t => Belt.Result.t('c, NonEmptyList.t(string)),
+    Js.Json.t => Belt.Result.t('d, NonEmptyList.t(string)),
+    Js.Json.t
+  ) =>
+  Belt.Result.t('e, NonEmptyList.t(string));
+
+let map5:
+  (
+    ('a, 'b, 'c, 'd, 'e) => 'f,
+    Js.Json.t => Belt.Result.t('a, NonEmptyList.t(string)),
+    Js.Json.t => Belt.Result.t('b, NonEmptyList.t(string)),
+    Js.Json.t => Belt.Result.t('c, NonEmptyList.t(string)),
+    Js.Json.t => Belt.Result.t('d, NonEmptyList.t(string)),
+    Js.Json.t => Belt.Result.t('e, NonEmptyList.t(string)),
+    Js.Json.t
+  ) =>
+  Belt.Result.t('f, NonEmptyList.t(string));
+
 module ResultUtil: {
   type r('a) = Belt.Result.t('a, NonEmptyList.t(string));
 
@@ -147,48 +189,6 @@ let oneOf:
 module Pipeline: {
   let succeed: ('a, 'b) => Belt.Result.t('a, NonEmptyList.t(string));
 
-  let map2:
-    (
-      ('a, 'b) => 'c,
-      'd => Belt.Result.t('a, NonEmptyList.t(string)),
-      'd => Belt.Result.t('b, NonEmptyList.t(string)),
-      'd
-    ) =>
-    Belt.Result.t('c, NonEmptyList.t(string));
-
-  let map3:
-    (
-      ('a, 'b, 'c) => 'd,
-      'e => Belt.Result.t('a, NonEmptyList.t(string)),
-      'e => Belt.Result.t('b, NonEmptyList.t(string)),
-      'e => Belt.Result.t('c, NonEmptyList.t(string)),
-      'e
-    ) =>
-    Belt.Result.t('d, NonEmptyList.t(string));
-
-  let map4:
-    (
-      ('a, 'b, 'c, 'd) => 'e,
-      'f => Belt.Result.t('a, NonEmptyList.t(string)),
-      'f => Belt.Result.t('b, NonEmptyList.t(string)),
-      'f => Belt.Result.t('c, NonEmptyList.t(string)),
-      'f => Belt.Result.t('d, NonEmptyList.t(string)),
-      'f
-    ) =>
-    Belt.Result.t('e, NonEmptyList.t(string));
-
-  let map5:
-    (
-      ('a, 'b, 'c, 'd, 'e) => 'f,
-      'g => Belt.Result.t('a, NonEmptyList.t(string)),
-      'g => Belt.Result.t('b, NonEmptyList.t(string)),
-      'g => Belt.Result.t('c, NonEmptyList.t(string)),
-      'g => Belt.Result.t('d, NonEmptyList.t(string)),
-      'g => Belt.Result.t('e, NonEmptyList.t(string)),
-      'g
-    ) =>
-    Belt.Result.t('f, NonEmptyList.t(string));
-
   let field:
     (
       Js.Dict.key,
@@ -227,7 +227,11 @@ module Pipeline: {
     Belt.Result.t('b, NonEmptyList.t(string));
 
   let hardcoded:
-    ('a, 'b => Belt.Result.t('a => 'c, NonEmptyList.t(string)), 'b) =>
+    (
+      'a,
+      Js.Json.t => Belt.Result.t('a => 'c, NonEmptyList.t(string)),
+      Js.Json.t
+    ) =>
     Belt.Result.t('c, NonEmptyList.t(string));
 
   let run:

--- a/src/Decode_NonEmptyList.re
+++ b/src/Decode_NonEmptyList.re
@@ -1,0 +1,19 @@
+/**
+ * We re-export some of Relude.NonEmptyList to make it easier for downstream
+ * projects to work with the output of `bs-decode` without explicitly adding
+ * a dependency on Relude.
+ *
+ * Specifically, we add a module type, so that specific kinds of decoders can
+ * include this definition of `NonEmptyList` in their rei files.
+ */
+module type Nel = {
+  type t('a) = Relude.NonEmpty.List.t('a);
+  let make: ('a, list('a)) => t('a);
+  let pure: 'a => t('a);
+  let cons: ('a, t('a)) => t('a);
+  let map: ('a => 'b, t('a)) => t('b);
+  let foldLeft: (('b, 'a) => 'b, 'b, t('a)) => 'b;
+  let head: t('a) => 'a;
+  let tail: t('a) => list('a);
+  let toSequence: t('a) => list('a);
+};

--- a/test/Decode_Result_Custom_test.re
+++ b/test/Decode_Result_Custom_test.re
@@ -20,7 +20,7 @@ module R =
 
 module D = DecodeBase.DecodeBase(R.TransformError, R.Monad, R.Alt);
 
-let ((<$>), (>>=), (<|>)) = R.Infix.((<$>), (>>=), (<|>));
+let ((<$>), (>>=), (<|>)) = R.(Monad.map, Monad.flat_map, Alt.alt);
 
 module Color = {
   type t =

--- a/test/Decode_Result_Pipeline_test.re
+++ b/test/Decode_Result_Pipeline_test.re
@@ -7,8 +7,10 @@ module D = Decode.AsResult.OfParseError;
 let (string, number, object_, null) =
   Js.Json.(string, number, object_, null);
 
-let (succeed, map2, field, fallback, optionalField, hardcoded, run) =
-  D.Pipeline.(succeed, map2, field, fallback, optionalField, hardcoded, run);
+let map2 = D.map2;
+
+let (succeed, field, fallback, optionalField, hardcoded, run) =
+  D.Pipeline.(succeed, field, fallback, optionalField, hardcoded, run);
 
 let map = D.ResultUtil.Functor.map;
 

--- a/test/Decode_Result_test.re
+++ b/test/Decode_Result_test.re
@@ -395,24 +395,17 @@ describe("Test oneOf, trying multiple decoders", () => {
 
   let decoders =
     D.oneOf(
-      Nel.make(
-        json => makeS <$> D.string(json),
-        [
-          json => makeN <$> D.optional(D.floatFromNumber, json),
-          json => makeB <$> D.boolean(json),
-        ],
-      ),
+      json => makeS <$> D.string(json),
+      [
+        json => makeN <$> D.optional(D.floatFromNumber, json),
+        json => makeB <$> D.boolean(json),
+      ],
     );
 
   let badDecoders =
     D.oneOf(
-      Nel.make(
-        json => makeS <$> D.string(json),
-        [
-          json => makeS <$> D.string(json),
-          json => makeS <$> D.string(json),
-        ],
-      ),
+      json => makeS <$> D.string(json),
+      [json => makeS <$> D.string(json), json => makeS <$> D.string(json)],
     );
 
   test("First in oneOf list succeeds", () =>

--- a/test/Decode_Result_test.re
+++ b/test/Decode_Result_test.re
@@ -1,18 +1,16 @@
+open Relude.Globals;
 open Jest;
 open Expect;
 open Decode.ParseError;
-open Belt.Result;
 
 module D = Decode.AsResult.OfParseError;
 module Nel = D.NonEmptyList;
-
-let ((<$>), (<*>), (<|>), recoverWith, mapErr) =
-  D.ResultUtil.(Infix.(<$>), Infix.(<*>), Infix.(<|>), recoverWith, mapErr);
 
 /**
  * Sample module used to decode json into a record type
  */
 module User = {
+  let ((<$>), (<*>)) = (Result.map, Result.apply);
   type t = {
     name: string,
     age: int,
@@ -33,13 +31,19 @@ module User = {
 };
 
 module Parent = {
+  let ((<$>), (<*>)) = (Result.map, Result.apply);
   type t = {
     user: User.t,
     other: float,
   };
+
   let make = (user, other) => {user, other};
+
+  let sameplJson =
+    Js.(Dict.fromList([("user", User.jsonSample)]) |> Json.object_);
+
   let decode = obj =>
-    make <$> D.field("user", User.decode, obj) <*> Ok(3.14);
+    make <$> D.field("user", User.decode, obj) <*> Result.ok(3.14);
 };
 
 describe("Test value decoders", () => {
@@ -55,103 +59,103 @@ describe("Test value decoders", () => {
   let jsonDateNumber = Js.Json.number(dateNumber);
 
   test("Boolean succeeds on a boolean", () =>
-    expect(D.boolean(jsonBoolean)) |> toEqual(Ok(true))
+    expect(D.boolean(jsonBoolean)) |> toEqual(Result.ok(true))
   );
   test("Boolean fails on string", () =>
     expect(D.boolean(jsonString))
-    |> toEqual(Error(Val(`ExpectedBoolean, jsonString)))
+    |> toEqual(Result.error(Val(`ExpectedBoolean, jsonString)))
   );
   test("Boolean fails on number", () =>
     expect(D.boolean(jsonFloat))
-    |> toEqual(Error(Val(`ExpectedBoolean, jsonFloat)))
+    |> toEqual(Result.error(Val(`ExpectedBoolean, jsonFloat)))
   );
   test("Boolean fails on null", () =>
     expect(D.boolean(jsonNull))
-    |> toEqual(Error(Val(`ExpectedBoolean, jsonNull)))
+    |> toEqual(Result.error(Val(`ExpectedBoolean, jsonNull)))
   );
 
   test("String succeeds on string", () =>
-    expect(D.string(jsonString)) |> toEqual(Ok("Foo"))
+    expect(D.string(jsonString)) |> toEqual(Result.ok("Foo"))
   );
   test("String fails on boolean", () =>
     expect(D.string(jsonBoolean))
-    |> toEqual(Error(Val(`ExpectedString, jsonBoolean)))
+    |> toEqual(Result.error(Val(`ExpectedString, jsonBoolean)))
   );
   test("String fails on number", () =>
     expect(D.string(jsonFloat))
-    |> toEqual(Error(Val(`ExpectedString, jsonFloat)))
+    |> toEqual(Result.error(Val(`ExpectedString, jsonFloat)))
   );
   test("String fails on null", () =>
     expect(D.string(jsonNull))
-    |> toEqual(Error(Val(`ExpectedString, jsonNull)))
+    |> toEqual(Result.error(Val(`ExpectedString, jsonNull)))
   );
 
   test("Float succeeds on float", () =>
-    expect(D.floatFromNumber(jsonFloat)) |> toEqual(Ok(1.4))
+    expect(D.floatFromNumber(jsonFloat)) |> toEqual(Result.ok(1.4))
   );
   test("Float gives deprecated warning", () =>
-    expect(D.floatFromNumber(jsonFloat)) |> toEqual(Ok(1.4))
+    expect(D.floatFromNumber(jsonFloat)) |> toEqual(Result.ok(1.4))
   );
   test("Float succeeds on int", () =>
-    expect(D.floatFromNumber(jsonInt)) |> toEqual(Ok(4.0))
+    expect(D.floatFromNumber(jsonInt)) |> toEqual(Result.ok(4.0))
   );
   test("Float succeeds on zero", () =>
-    expect(D.floatFromNumber(jsonZero)) |> toEqual(Ok(0.))
+    expect(D.floatFromNumber(jsonZero)) |> toEqual(Result.ok(0.))
   );
   test("Float fails on boolean", () =>
     expect(D.floatFromNumber(jsonBoolean))
-    |> toEqual(Error(Val(`ExpectedNumber, jsonBoolean)))
+    |> toEqual(Result.error(Val(`ExpectedNumber, jsonBoolean)))
   );
   test("Float fails on string", () =>
     expect(D.floatFromNumber(jsonString))
-    |> toEqual(Error(Val(`ExpectedNumber, jsonString)))
+    |> toEqual(Result.error(Val(`ExpectedNumber, jsonString)))
   );
   test("Float fails on null", () =>
     expect(D.floatFromNumber(jsonNull))
-    |> toEqual(Error(Val(`ExpectedNumber, jsonNull)))
+    |> toEqual(Result.error(Val(`ExpectedNumber, jsonNull)))
   );
 
   test("Int succeeds on int", () =>
-    expect(D.intFromNumber(jsonInt)) |> toEqual(Ok(4))
+    expect(D.intFromNumber(jsonInt)) |> toEqual(Result.ok(4))
   );
   test("Int gives deprecation warning", () =>
-    expect(D.intFromNumber(jsonInt)) |> toEqual(Ok(4))
+    expect(D.intFromNumber(jsonInt)) |> toEqual(Result.ok(4))
   );
   test("Int succeeds on 0", () =>
-    expect(D.intFromNumber(jsonZero)) |> toEqual(Ok(0))
+    expect(D.intFromNumber(jsonZero)) |> toEqual(Result.ok(0))
   );
   test("Int fails on float", () =>
     expect(D.intFromNumber(jsonFloat))
-    |> toEqual(Error(Val(`ExpectedInt, jsonFloat)))
+    |> toEqual(Result.error(Val(`ExpectedInt, jsonFloat)))
   );
   test("Int fails on boolean", () =>
     expect(D.intFromNumber(jsonBoolean))
-    |> toEqual(Error(Val(`ExpectedNumber, jsonBoolean)))
+    |> toEqual(Result.error(Val(`ExpectedNumber, jsonBoolean)))
   );
   test("Int fails on string", () =>
     expect(D.intFromNumber(jsonString))
-    |> toEqual(Error(Val(`ExpectedNumber, jsonString)))
+    |> toEqual(Result.error(Val(`ExpectedNumber, jsonString)))
   );
   test("Int fails on null", () =>
     expect(D.intFromNumber(jsonNull))
-    |> toEqual(Error(Val(`ExpectedNumber, jsonNull)))
+    |> toEqual(Result.error(Val(`ExpectedNumber, jsonNull)))
   );
 
   test("Date succeeds on number value", () =>
     expect(D.date(jsonDateNumber))
-    |> toEqual(Ok(dateNumber->Js.Date.fromFloat))
+    |> toEqual(Result.ok(Js.Date.fromFloat(dateNumber)))
   );
   test("Date succeeds on string value", () =>
     expect(D.date(jsonDateString))
-    |> toEqual(Ok(dateString->Js.Date.fromString))
+    |> toEqual(Result.ok(Js.Date.fromString(dateString)))
   );
   test("Date fails on an invalid date value", () =>
     expect(D.date(jsonString))
-    |> toEqual(Error(Val(`ExpectedValidDate, jsonString)))
+    |> toEqual(Result.error(Val(`ExpectedValidDate, jsonString)))
   );
   test("Date fails on a null value", () =>
     expect(D.date(jsonNull))
-    |> toEqual(Error(Val(`ExpectedString, jsonNull)))
+    |> toEqual(Result.error(Val(`ExpectedString, jsonNull)))
   );
 });
 
@@ -166,40 +170,34 @@ type numbers =
 
 describe("Test decoding variants as option", () => {
   test("Can decode string variants", () =>
-    expect(D.variantFromString(colorFromJs, "blue"->Js.Json.string))
-    |> toEqual(Ok(`blue))
+    expect(D.variantFromString(colorFromJs, Js.Json.string("blue")))
+    |> toEqual(Result.ok(`blue))
   );
   test("Can decode number variants", () =>
-    expect(D.variantFromInt(numbersFromJs, 0->float_of_int->Js.Json.number))
-    |> toEqual(Ok(Zero))
+    expect(D.variantFromInt(numbersFromJs, Js.Json.number(0.0)))
+    |> toEqual(Result.ok(Zero))
   );
   test("Can fail on invalid string options", () =>
-    expect(D.variantFromString(colorFromJs, "yellow"->Js.Json.string))
-    |> toEqual(Error(Val(`ExpectedValidOption, "yellow"->Js.Json.string)))
+    expect(D.variantFromString(colorFromJs, Js.Json.string("yellow")))
+    |> toEqual(
+         Result.error(Val(`ExpectedValidOption, Js.Json.string("yellow"))),
+       )
   );
   test("Can fail on invalid number options", () =>
-    expect(D.variantFromInt(numbersFromJs, 5->float_of_int->Js.Json.number))
+    expect(D.variantFromInt(numbersFromJs, Js.Json.number(5.0)))
     |> toEqual(
-         Error(Val(`ExpectedValidOption, 5->float_of_int->Js.Json.number)),
+         Result.error(Val(`ExpectedValidOption, Js.Json.number(5.0))),
        )
   );
 });
 
 describe("Test array decoders", () => {
   let jsonArray =
-    Js.Json.array([|
-      Js.Json.string("a"),
-      Js.Json.string("b"),
-      Js.Json.string("c"),
-    |]);
+    Js.Json.(array([|string("a"), string("b"), string("c")|]));
   let jsonEmptyArray = Js.Json.array([||]);
   let jsonString = Js.Json.string("Foo");
   let jsonArrayMixed =
-    Js.Json.array([|
-      Js.Json.string("a"),
-      Js.Json.string("b"),
-      Js.Json.number(3.5),
-    |]);
+    Js.Json.(array([|string("a"), string("b"), number(3.5)|]));
 
   let numError = str => Val(`ExpectedNumber, Js.Json.string(str));
 
@@ -210,87 +208,98 @@ describe("Test array decoders", () => {
     );
 
   test("Array succeeds on array of string", () =>
-    expect(D.array(D.string, jsonArray)) |> toEqual(Ok([|"a", "b", "c"|]))
+    expect(D.array(D.string, jsonArray))
+    |> toEqual(Result.ok([|"a", "b", "c"|]))
   );
   test("Array string succeeds on empty array", () =>
-    expect(D.array(D.string, jsonEmptyArray)) |> toEqual(Ok([||]))
+    expect(D.array(D.string, jsonEmptyArray)) |> toEqual(Result.ok([||]))
   );
   test("Array int succeeds on empty array", () =>
-    expect(D.array(D.intFromNumber, jsonEmptyArray)) |> toEqual(Ok([||]))
+    expect(D.array(D.intFromNumber, jsonEmptyArray))
+    |> toEqual(Result.ok([||]))
   );
   test("Array fails on string", () =>
     expect(D.array(D.string, jsonString))
-    |> toEqual(Error(Val(`ExpectedArray, jsonString)))
+    |> toEqual(Result.error(Val(`ExpectedArray, jsonString)))
   );
   test("Array inner decode int fails on array of string", () =>
     expect(D.array(D.intFromNumber, jsonArray))
-    |> toEqual(Error(Arr(decodeErrs)))
+    |> toEqual(Result.error(Arr(decodeErrs)))
   );
   test("Array fails on mixed array", () =>
     expect(D.array(D.string, jsonArrayMixed))
     |> toEqual(
-         Error(
+         Result.error(
            Arr(Nel.pure((2, Val(`ExpectedString, Js.Json.number(3.5))))),
          ),
        )
   );
 
   test("List succeeds on JSON array of string", () =>
-    expect(D.list(D.string, jsonArray)) |> toEqual(Ok(["a", "b", "c"]))
+    expect(D.list(D.string, jsonArray))
+    |> toEqual(Result.ok(["a", "b", "c"]))
   );
   test("List fails on JSON null", () =>
     expect(D.list(D.string, Js.Json.null))
-    |> toEqual(Error(Val(`ExpectedArray, Js.Json.null)))
+    |> toEqual(Result.error(Val(`ExpectedArray, Js.Json.null)))
   );
   test("List inner decode int fails on array of string", () =>
     expect(D.list(D.intFromNumber, jsonArray))
-    |> toEqual(Error(Arr(decodeErrs)))
+    |> toEqual(Result.error(Arr(decodeErrs)))
   );
 });
 
 describe("Test record field decoders", () => {
-  let (string, object_) = Js.Json.(string, object_);
-  let obj = User.jsonSample;
-
-  let parentObj = Js.Dict.fromList([("user", obj)]) |> object_;
-  let nameAsIntError = InvalidField(Val(`ExpectedNumber, string("Foo")));
-  let decoded = User.decode(obj);
+  let nameAsIntError =
+    InvalidField(Val(`ExpectedNumber, Js.Json.string("Foo")));
 
   let decodeFail =
-    User.make
-    <$> D.field("missing", D.string, obj)
-    <*> D.field("name", D.intFromNumber, obj);
-
-  let decodeErrors =
-    Error(
-      Obj(
-        Nel.make(("missing", MissingField), [("name", nameAsIntError)]),
-      ),
+    D.map2(
+      User.make,
+      D.field("missing", D.string),
+      D.field("name", D.intFromNumber),
+      User.jsonSample,
     );
 
+  // TODO: why does this seem to put the errors in the opposite order?
+  // let decodeFail =
+  //   D.Pipeline.(
+  //     succeed(User.make)
+  //     |> field("missing", D.string)
+  //     |> field("name", D.intFromNumber)
+  //     |> run(User.jsonSample)
+  //   );
+
+  let decodeErrors =
+    Obj(Nel.make(("missing", MissingField), [("name", nameAsIntError)]))
+    |> Result.error;
+
   test("String field succeeds", () =>
-    expect(D.field("name", D.string, obj)) |> toEqual(Ok("Foo"))
+    expect(D.field("name", D.string, User.jsonSample))
+    |> toEqual(Result.ok("Foo"))
   );
   test("Int field succeeds", () =>
-    expect(D.field("age", D.intFromNumber, obj)) |> toEqual(Ok(30))
+    expect(D.field("age", D.intFromNumber, User.jsonSample))
+    |> toEqual(Result.ok(30))
   );
   test("Field fails when missing", () =>
-    expect(D.field("blah", D.intFromNumber, obj))
-    |> toEqual(Error(objPure("blah", MissingField)))
+    expect(D.field("blah", D.intFromNumber, User.jsonSample))
+    |> toEqual(Result.error(objPure("blah", MissingField)))
   );
   test("Field fails on wrong type", () =>
-    expect(D.field("name", D.intFromNumber, obj))
-    |> toEqual(Error(objPure("name", nameAsIntError)))
+    expect(D.field("name", D.intFromNumber, User.jsonSample))
+    |> toEqual(Result.error(objPure("name", nameAsIntError)))
   );
   test("Decode all fields of user record into User", () =>
-    expect(decoded) |> toEqual(Ok(User.make("Foo", 30)))
+    expect(User.decode(User.jsonSample))
+    |> toEqual(Result.ok(User.make("Foo", 30)))
   );
   test("Decode as user with incorrect fields fails", () =>
     expect(decodeFail) |> toEqual(decodeErrors)
   );
   test("Decode parent record with child record field", () =>
-    expect(Parent.decode(parentObj))
-    |> toEqual(Ok(Parent.make(User.make("Foo", 30), 3.14)))
+    expect(Parent.decode(Parent.sameplJson))
+    |> toEqual(Result.ok(Parent.make(User.make("Foo", 30), 3.14)))
   );
 });
 
@@ -304,18 +313,22 @@ describe("Test value and field recovery from failed parse", () => {
     |> Js.Json.object_;
 
   let objRecovery =
-    User.make
-    <$> D.fallback("name", D.string, "Foo", invalidUserObj)
-    <*> D.field("age", D.intFromNumber, invalidUserObj);
+    D.map2(
+      User.make,
+      D.fallback("name", D.string, "Foo"),
+      D.field("age", D.intFromNumber),
+      invalidUserObj,
+    );
 
   test("Failed parse can be recovered with literal value", () =>
-    expect(failedParse |> recoverWith("foo")) |> toEqual(Ok("foo"))
+    expect(failedParse |> Result.recover("foo"))
+    |> toEqual(Result.ok("foo"))
   );
   test("Successful parse is unaffected by recovery", () =>
-    expect(successParse |> recoverWith(1.0)) |> toEqual(Ok(3.14))
+    expect(successParse |> Result.recover(1.0)) |> toEqual(Result.ok(3.14))
   );
   test("Bad field recovers with fallback", () =>
-    expect(objRecovery) |> toEqual(Ok(User.make("Foo", 30)))
+    expect(objRecovery) |> toEqual(Result.ok(User.make("Foo", 30)))
   );
 });
 
@@ -338,38 +351,39 @@ describe("Test optionally empty fields and values", () => {
   let nullValueInt = D.field("n", D.optional(D.intFromNumber), obj);
 
   test("Present value parses as Some string", () =>
-    expect(optStr(jsonString)) |> toEqual(Ok(Some("Foo")))
+    expect(optStr(jsonString)) |> toEqual(Result.ok(Some("Foo")))
   );
   test("Null value parses as None", () =>
-    expect(optStr(jsonNull)) |> toEqual(Ok(None))
+    expect(optStr(jsonNull)) |> toEqual(Result.ok(None))
   );
   test("Present value of incorrect type is still an Error", () =>
     expect(optStr(jsonInt))
-    |> toEqual(Error(Val(`ExpectedString, jsonInt)))
+    |> toEqual(Result.error(Val(`ExpectedString, jsonInt)))
   );
 
   test("Present field and value is Some when field is optional", () =>
-    expect(optFieldString) |> toEqual(Ok(Some("Foo")))
+    expect(optFieldString) |> toEqual(Result.ok(Some("Foo")))
   );
   test("Present field and value is Some when value is optional", () =>
-    expect(reqFieldOptValueString) |> toEqual(Ok(Some("Foo")))
+    expect(reqFieldOptValueString) |> toEqual(Result.ok(Some("Foo")))
   );
   test("If int field is missing, it parses as None if field is optional", () =>
-    expect(optFieldInt) |> toEqual(Ok(None))
+    expect(optFieldInt) |> toEqual(Result.ok(None))
   );
   test(
     "If int field is missing, it parses as Error if only value is optional", () =>
-    expect(optValueInt) |> toEqual(Error(objPure("x", MissingField)))
+    expect(optValueInt)
+    |> toEqual(Result.error(objPure("x", MissingField)))
   );
   test("Present field with null value parses as None for optional field", () =>
-    expect(nullFieldInt) |> toEqual(Ok(None))
+    expect(nullFieldInt) |> toEqual(Result.ok(None))
   );
   test("Present field with null value parses as None for optional value", () =>
-    expect(nullValueInt) |> toEqual(Ok(None))
+    expect(nullValueInt) |> toEqual(Result.ok(None))
   );
   test("Trying to parse string field as int is Error, not None", () =>
     expect(D.optionalField("s", D.intFromNumber, obj))
-    |> toEqual(Error(Val(`ExpectedNumber, jsonString)))
+    |> toEqual(Result.error(Val(`ExpectedNumber, jsonString)))
   );
 });
 
@@ -395,30 +409,34 @@ describe("Test oneOf, trying multiple decoders", () => {
 
   let decoders =
     D.oneOf(
-      json => makeS <$> D.string(json),
+      json => Result.map(makeS, D.string(json)),
       [
-        json => makeN <$> D.optional(D.floatFromNumber, json),
-        json => makeB <$> D.boolean(json),
+        json => Result.map(makeN, D.optional(D.floatFromNumber, json)),
+        json => Result.map(makeB, D.boolean(json)),
       ],
     );
 
   let badDecoders =
     D.oneOf(
-      json => makeS <$> D.string(json),
-      [json => makeS <$> D.string(json), json => makeS <$> D.string(json)],
+      json => Result.map(makeS, D.string(json)),
+      [
+        json => Result.map(makeS, D.string(json)),
+        json => Result.map(makeS, D.string(json)),
+      ],
     );
 
   test("First in oneOf list succeeds", () =>
     expect(D.field("strField", decoders, json))
-    |> toEqual(Ok(S("string")))
+    |> toEqual(Result.ok(S("string")))
   );
 
   test("Last in oneOf list succeeds", () =>
-    expect(D.field("boolField", decoders, json)) |> toEqual(Ok(B(false)))
+    expect(D.field("boolField", decoders, json))
+    |> toEqual(Result.ok(B(false)))
   );
 
   test("All decoders in oneOf fail", () =>
     expect(badDecoders(Js.Json.boolean(false)))
-    |> toEqual(Error(Val(`ExpectedString, Js.Json.boolean(false))))
+    |> toEqual(Result.error(Val(`ExpectedString, Js.Json.boolean(false))))
   );
 });

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -14,6 +14,9 @@
       "decoding-simple-values": {
         "title": "Simple Values"
       },
+      "decoding-variants": {
+        "title": "Decoding Variants"
+      },
       "handling-errors": {
         "title": "Handling Errors"
       },


### PR DESCRIPTION
This collection of changes is focused on:

- Making decoders composable by adding `map`, `apply`, `flatMap`, and friends
- Cleaning up the public-facing API by removing big utility modules from the interface
- Updating dependencies (bump bs-abstract to the latest, replace bs-nonempty with Relude)
- Making our internal code style more consistent (by decreasing the use of infix functions, among other things)