### PR TITLE
Move relude and bs-abstract into peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -825,7 +825,8 @@
     "bs-abstract": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/bs-abstract/-/bs-abstract-0.17.0.tgz",
-      "integrity": "sha512-J1sPz2EZS29Ga0YdOVV8wD7PPKpCxrpEgMKLcehXNseSNxiWgmg4mxmJEhRva/d/d0LpjM4HysBiuCDwZ1FTNQ=="
+      "integrity": "sha512-J1sPz2EZS29Ga0YdOVV8wD7PPKpCxrpEgMKLcehXNseSNxiWgmg4mxmJEhRva/d/d0LpjM4HysBiuCDwZ1FTNQ==",
+      "dev": true
     },
     "bs-platform": {
       "version": "5.0.4",
@@ -1606,8 +1607,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1628,14 +1628,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1650,20 +1648,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1780,8 +1775,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1793,7 +1787,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1808,7 +1801,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1816,14 +1808,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1842,7 +1832,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1923,8 +1912,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1936,7 +1924,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2022,8 +2009,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2059,7 +2045,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2079,7 +2064,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2123,14 +2107,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -3989,7 +3971,8 @@
     "relude": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/relude/-/relude-0.12.1.tgz",
-      "integrity": "sha512-rhMm0Zewrw7X5dzg95au9I8Y+nVcnummezPXtk/FGeS7nq7AGviS7wn+cOmW719OfdV7iTneybckLlRx3mVtVQ=="
+      "integrity": "sha512-rhMm0Zewrw7X5dzg95au9I8Y+nVcnummezPXtk/FGeS7nq7AGviS7wn+cOmW719OfdV7iTneybckLlRx3mVtVQ==",
+      "dev": true
     },
     "remove-trailing-separator": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -31,15 +31,17 @@
   ],
   "author": "Michael Martin-Smucker",
   "license": "MIT",
-  "dependencies": {
+  "peerDependencies": {
     "bs-abstract": "^0.17.0",
     "relude": "^0.12.1"
   },
   "devDependencies": {
     "@glennsl/bs-jest": "^0.4.8",
+    "bs-abstract": "^0.17.0",
     "bs-platform": "^5.0.3",
     "coveralls": "^3.0.3",
-    "jest": "^24.8.0"
+    "jest": "^24.8.0",
+    "relude": "^0.12.1"
   },
   "jest": {
     "coveragePathIgnorePatterns": [


### PR DESCRIPTION
When using both relude and/or bs-abstract in a project you can get the `duplicated packages` warning which then breaks the code in runtime.

By moving these into peer dependencies it stops npm from double installing them and then everything lines up 👌 