### PR TITLE
Add missing error info to optionalField

### DIFF
--- a/src/DecodeBase.re
+++ b/src/DecodeBase.re
@@ -234,7 +234,8 @@ module DecodeBase = (T: TransformError, M: MONAD with type t('a) = T.t('a)) => {
          fun
          | None => pure(None)
          | Some(v) => (_ => optional(decode, v)),
-       );
+       )
+    >> T.objErr(name);
 
   let fallback = (decode, recovery) => alt(decode, pure(recovery));
 


### PR DESCRIPTION
This adds information about on what field the decoding failed when using `optionalField`