### PR TITLE
More deprecations, literal helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,11 @@
     "relude": "^0.66.1"
   },
   "jest": {
+    "testPathIgnorePatterns": [
+      "./test/output",
+      "_build",
+      "_opam"
+    ],
     "coveragePathIgnorePatterns": [
       "./test"
     ],

--- a/src/Decode.re
+++ b/src/Decode.re
@@ -5,7 +5,9 @@ module Make = Base.Make;
 
 module ParseError = Decode_ParseError;
 
+[@deprecated "Use Decode.ParseError instead"]
 module AsOption = Decode_AsOption;
+
 module AsResult = {
   module OfParseError = Decode_AsResult_OfParseError;
 

--- a/src/Decode_AsResult_OfParseError.rei
+++ b/src/Decode_AsResult_OfParseError.rei
@@ -90,9 +90,25 @@ let literal:
 let literalString: (string, Js.Json.t) => result(string, ParseError.failure);
 let literalInt: (int, Js.Json.t) => result(int, ParseError.failure);
 let literalFloat: (float, Js.Json.t) => result(float, ParseError.failure);
+let literalBool: (bool, Js.Json.t) => result(bool, ParseError.failure);
+let literalTrue: Js.Json.t => result(bool, ParseError.failure);
+let literalFalse: Js.Json.t => result(bool, ParseError.failure);
+
+let union:
+  (
+    ('a, Js.Json.t) => result('a, ParseError.failure),
+    ('a, 'b),
+    list(('a, 'b)),
+    Js.Json.t
+  ) =>
+  result('b, ParseError.failure);
+
 let stringUnion:
   ((string, 'a), list((string, 'a)), Js.Json.t) =>
   result('a, ParseError.failure);
+
+let intUnion:
+  ((int, 'a), list((int, 'a)), Js.Json.t) => result('a, ParseError.failure);
 
 [@deprecated "Use literal instead"]
 let variantFromJson:

--- a/src/Decode_AsResult_OfParseError.rei
+++ b/src/Decode_AsResult_OfParseError.rei
@@ -248,6 +248,9 @@ let oneOf:
   ) =>
   result('a, ParseError.failure);
 
+let hush:
+  (Js.Json.t => result('a, ParseError.failure), Js.Json.t) => option('a);
+
 [@deprecated "Will be removed in favor up the upcoming addition of letops"]
 module Pipeline: {
   let succeed: ('a, Js.Json.t) => result('a, ParseError.failure);

--- a/src/Decode_AsResult_OfParseError.rei
+++ b/src/Decode_AsResult_OfParseError.rei
@@ -93,6 +93,8 @@ let literalFloat: (float, Js.Json.t) => result(float, ParseError.failure);
 let stringUnion:
   ((string, 'a), list((string, 'a)), Js.Json.t) =>
   result('a, ParseError.failure);
+
+[@deprecated "Use literal instead"]
 let variantFromJson:
   (
     Js.Json.t => result('a, ParseError.failure),
@@ -100,8 +102,12 @@ let variantFromJson:
     Js.Json.t
   ) =>
   result('b, ParseError.failure);
+
+[@deprecated "Use stringUnion instead"]
 let variantFromString:
   (string => option('a), Js.Json.t) => result('a, ParseError.failure);
+
+[@deprecated "Use literalInt and alt/oneOf instead"]
 let variantFromInt:
   (int => option('a), Js.Json.t) => result('a, ParseError.failure);
 
@@ -213,6 +219,7 @@ let dict:
   (Js.Json.t => result('a, ParseError.failure), Js.Json.t) =>
   result(Js.Dict.t('a), ParseError.failure);
 
+[@deprecated "Use dict instead, and convert the Dict to a Map"]
 let stringMap:
   (Js.Json.t => result('a, ParseError.failure), Js.Json.t) =>
   result(Belt.Map.String.t('a), ParseError.failure);

--- a/src/Decode_Base.re
+++ b/src/Decode_Base.re
@@ -65,10 +65,20 @@ module Make =
 
   let literalFloat = literal((==), floatFromNumber);
 
-  let stringUnion = (first, rest) => {
-    let mkDecode = ((s, v)) => literalString(s) |> map(_ => v);
+  let literalBool = literal((==), boolean);
+
+  let literalTrue = literalBool(true);
+
+  let literalFalse = literalBool(false);
+
+  let union = (decode, first, rest) => {
+    let mkDecode = ((s, v)) => decode(s) |> map(_ => v);
     first |> mkDecode |> oneOf(_, rest |> List.map(mkDecode));
   };
+
+  let stringUnion = first => union(literalString, first);
+
+  let intUnion = first => union(literalInt, first);
 
   let variantFromJson = (jsonToJs, jsToVariant) =>
     jsonToJs

--- a/src/Decode_Base.re
+++ b/src/Decode_Base.re
@@ -214,6 +214,8 @@ module Make =
   let tupleFromFields = ((fieldA, decodeA), (fieldB, decodeB)) =>
     map2(Tuple.make, field(fieldA, decodeA), field(fieldB, decodeB));
 
+  let hush = (decode, json) => decode(json) |> Result.toOption;
+
   module Pipeline = {
     let succeed = pure;
 

--- a/src/Decode_Base.re
+++ b/src/Decode_Base.re
@@ -69,6 +69,7 @@ module Make =
     let mkDecode = ((s, v)) => literalString(s) |> map(_ => v);
     first |> mkDecode |> oneOf(_, rest |> List.map(mkDecode));
   };
+
   let variantFromJson = (jsonToJs, jsToVariant) =>
     jsonToJs
     |> map(jsToVariant)

--- a/test/Decode_AsOption_test.re
+++ b/test/Decode_AsOption_test.re
@@ -8,7 +8,7 @@ module Sample = Decode_TestSampleData;
 
 describe("Simple decoders", () => {
   test("bool (success)", () =>
-    expect(Decode.boolean(Sample.jsonBool))
+    expect(Decode.boolean(Sample.jsonTrue))
     |> toEqual(Some(Sample.valBool))
   );
 
@@ -182,7 +182,7 @@ describe("Nested decoders", () => {
   );
 
   test("optional float (fails on bool)", () =>
-    expect(Decode.(optional(floatFromNumber, Sample.jsonBool)))
+    expect(Decode.(optional(floatFromNumber, Sample.jsonTrue)))
     |> toEqual(None)
   );
 
@@ -225,7 +225,7 @@ describe("Nested decoders", () => {
   );
 
   test("tuple2 (fails on non-array)", () =>
-    expect(Decode.(tuple(string, boolean, Sample.jsonBool)))
+    expect(Decode.(tuple(string, boolean, Sample.jsonTrue)))
     |> toEqual(None)
   );
 
@@ -429,7 +429,7 @@ describe("Decode with alternatives/fallbacks", () => {
   );
 
   test("oneOf (succeeds on last)", () =>
-    expect(decodeUnion(Sample.jsonBool))
+    expect(decodeUnion(Sample.jsonTrue))
     |> toEqual(Some(Sample.(B(valBool))))
   );
 

--- a/test/Decode_AsOption_test.re
+++ b/test/Decode_AsOption_test.re
@@ -2,6 +2,7 @@ open Jest;
 open Expect;
 open Relude.Globals;
 
+[@ocaml.warning "-3"]
 module Decode = Decode.AsOption;
 module Sample = Decode_TestSampleData;
 

--- a/test/Decode_AsResult_OfParseError_test.re
+++ b/test/Decode_AsResult_OfParseError_test.re
@@ -67,6 +67,7 @@ describe("Simple decoders", () => {
   );
 
   test("variant", () =>
+    [@ocaml.warning "-3"]
     expect(Decode.variantFromString(Sample.colorFromJs, Sample.jsonString))
     |> toEqual(valErr(`ExpectedValidOption, Sample.jsonString))
   );

--- a/test/Decode_AsResult_OfParseError_test.re
+++ b/test/Decode_AsResult_OfParseError_test.re
@@ -14,6 +14,18 @@ let objErr = (first, rest) =>
 
 let objErrSingle = (field, err) => objErr((field, err), []);
 
+describe("Decode utils", () => {
+  test("hush (success)", () => {
+    let decodeBooleanOpt = Decode.(boolean |> hush);
+    expect(decodeBooleanOpt(Sample.jsonBool)) |> toEqual(Some(true));
+  });
+
+  test("hush (failure)", () => {
+    let decodeStringOpt = Decode.(string |> hush);
+    expect(decodeStringOpt(Sample.jsonNull)) |> toEqual(None);
+  });
+});
+
 describe("Simple decoders", () => {
   test("boolean", () =>
     expect(Decode.boolean(Sample.jsonNull))

--- a/test/Decode_AsResult_OfParseError_test.re
+++ b/test/Decode_AsResult_OfParseError_test.re
@@ -17,7 +17,7 @@ let objErrSingle = (field, err) => objErr((field, err), []);
 describe("Decode utils", () => {
   test("hush (success)", () => {
     let decodeBooleanOpt = Decode.(boolean |> hush);
-    expect(decodeBooleanOpt(Sample.jsonBool)) |> toEqual(Some(true));
+    expect(decodeBooleanOpt(Sample.jsonTrue)) |> toEqual(Some(true));
   });
 
   test("hush (failure)", () => {
@@ -27,6 +27,9 @@ describe("Decode utils", () => {
 });
 
 describe("Simple decoders", () => {
+  let decodeIntColor =
+    Decode.intUnion((0, `blue), [(1, `red), (2, `green)]);
+
   test("boolean", () =>
     expect(Decode.boolean(Sample.jsonNull))
     |> toEqual(valErr(`ExpectedBoolean, Sample.jsonNull))
@@ -71,6 +74,48 @@ describe("Simple decoders", () => {
                NonEmpty.List.make(
                  Val(`ExpectedNumber, Sample.jsonNull),
                  [Val(`ExpectedString, Sample.jsonNull)],
+               ),
+             )
+           ),
+         ),
+       )
+  );
+
+  test("literalTrue (success)", () =>
+    expect(Decode.literalTrue(Sample.jsonTrue)) |> toEqual(Result.ok(true))
+  );
+
+  test("literalTrue (failure)", () =>
+    expect(Decode.literalTrue(Sample.jsonFalse))
+    |> toEqual(valErr(`ExpectedValidOption, Sample.jsonFalse))
+  );
+
+  test("literalFalse (success)", () =>
+    expect(Decode.literalFalse(Sample.jsonFalse))
+    |> toEqual(Result.ok(false))
+  );
+
+  test("literalFalse (failure)", () =>
+    expect(Decode.literalFalse(Sample.jsonTrue))
+    |> toEqual(valErr(`ExpectedValidOption, Sample.jsonTrue))
+  );
+
+  test("intUnion (success)", () =>
+    expect(decodeIntColor(Sample.jsonIntZero)) |> toEqual(Result.ok(`blue))
+  );
+
+  test("intUnion (failure)", () =>
+    expect(decodeIntColor(Sample.jsonIntFive))
+    |> toEqual(
+         Result.error(
+           Decode.ParseError.(
+             TriedMultiple(
+               NonEmpty.List.make(
+                 Val(`ExpectedValidOption, Sample.jsonIntFive),
+                 [
+                   Val(`ExpectedValidOption, Sample.jsonIntFive),
+                   Val(`ExpectedValidOption, Sample.jsonIntFive),
+                 ],
                ),
              )
            ),
@@ -181,7 +226,7 @@ describe("Inner decoders", () => {
   );
 
   test("oneOf (success on last)", () =>
-    expect(decodeUnion(Sample.jsonBool))
+    expect(decodeUnion(Sample.jsonTrue))
     |> toEqual(Result.ok(Sample.B(Sample.valBool)))
   );
 

--- a/test/Decode_AsResult_OfStringNel_test.re
+++ b/test/Decode_AsResult_OfStringNel_test.re
@@ -127,7 +127,7 @@ describe("Inner decoders", () => {
         )
       );
 
-    expect(decodeUnion(Sample.jsonBool))
+    expect(decodeUnion(Sample.jsonTrue))
     |> toEqual(Result.ok(Sample.(B(valBool))));
   });
 });

--- a/test/utils/Decode_TestSampleData.re
+++ b/test/utils/Decode_TestSampleData.re
@@ -1,6 +1,7 @@
 // Simple JSON values
 let jsonNull: Js.Json.t = [%raw {| null |}];
-let jsonBool: Js.Json.t = [%raw {| true |}];
+let jsonTrue: Js.Json.t = [%raw {| true |}];
+let jsonFalse: Js.Json.t = [%raw {| false |}];
 let jsonString: Js.Json.t = [%raw {| "string" |}];
 let jsonStringTrue: Js.Json.t = [%raw {| "true" |}];
 let jsonString4: Js.Json.t = [%raw {| "4" |}];


### PR DESCRIPTION
This deprecates the remaining functions that were mentioned in the last release notes. Additionally, it adds:

- `literalBool`, `literalTrue`, and `literalFalse`
- `intUnion` (like `stringUnion`, replacing `variantFromInt`)
- `union` (for building custom unions that follow the `intUnion` and `stringUnion` pattern)