### PR TITLE
fix: reject out-of-bounds numbers as ints

### DIFF
--- a/src/Decode_Base.re
+++ b/src/Decode_Base.re
@@ -38,7 +38,7 @@ module Make =
   let floatFromNumber = value(Js.Json.decodeNumber, `ExpectedNumber);
 
   let intFromNumber = {
-    let isInt = v => v == 0.0 || mod_float(v, floor(v)) == 0.0;
+    let isInt = num => float(int_of_float(num)) == num;
     flatMap(
       v => isInt(v) ? pure(int_of_float(v)) : T.valErr(`ExpectedInt),
       floatFromNumber,

--- a/test/Decode_AsResult_OfParseError_test.re
+++ b/test/Decode_AsResult_OfParseError_test.re
@@ -64,6 +64,11 @@ describe("Simple decoders", () => {
     |> toEqual(valErr(`ExpectedNumber, Sample.jsonString4))
   );
 
+  test("intFromNumber (out-of-range int)", () =>
+    expect(Decode.intFromNumber(Sample.jsonLargeFloat))
+    |> toEqual(valErr(`ExpectedInt, Sample.jsonLargeFloat))
+  );
+
   test("intFromNumber (float)", () =>
     expect(Decode.intFromNumber(Sample.jsonFloat))
     |> toEqual(valErr(`ExpectedInt, Sample.jsonFloat))

--- a/test/utils/Decode_TestSampleData.re
+++ b/test/utils/Decode_TestSampleData.re
@@ -7,6 +7,7 @@ let jsonStringTrue: Js.Json.t = [%raw {| "true" |}];
 let jsonString4: Js.Json.t = [%raw {| "4" |}];
 let jsonFloat: Js.Json.t = [%raw {| 3.14 |}];
 let jsonInt: Js.Json.t = [%raw {| 1 |}];
+let jsonLargeFloat: Js.Json.t = [%raw {|1542433304450|}];
 let jsonIntZero: Js.Json.t = [%raw {| 0 |}];
 let jsonDateNumber: Js.Json.t = [%raw {| 1542433304450.0 |}];
 let jsonDateString: Js.Json.t = [%raw {| "2018-11-17T05:40:35.869Z" |}];


### PR DESCRIPTION
fixes #137 